### PR TITLE
[FEAT] 마이페이지 라운지게시물 내가 쓴 게시물만 가져오기 

### DIFF
--- a/src/api/posts.ts
+++ b/src/api/posts.ts
@@ -1,7 +1,16 @@
 import axiosInstance from "@/lib/axios";
 import { Posts } from "@/types";
 
-export async function getPosts(): Promise<Posts[]> {
-  const { data } = await axiosInstance.get("/posts");
+interface GetPostsParams {
+  type?: string;
+  keyword?: string;
+  sortBy?: string;
+  sortOrder?: string;
+  cursor?: string;
+  size?: number;
+}
+
+export async function getPosts(params?: GetPostsParams): Promise<Posts[]> {
+  const { data } = await axiosInstance.get("/posts", { params });
   return data.data;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -28,7 +28,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} antialiased bg-gray-50`}
         suppressHydrationWarning
       >
         <QueryProvider>

--- a/src/app/users/[id]/page.tsx
+++ b/src/app/users/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import Image from "next/image";
 
@@ -20,6 +20,13 @@ import {
   updateFavorites,
 } from "@/api/meeting";
 import LoungePostListCommon from "@/components/common/LoungePostListCommon";
+import { useAuthStore } from "@/store/useAuthStore";
+import {
+  PaginationEllipsis,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+} from "@/components/common/PaginationCommon";
 
 const mockMeeting: Meeting = {
   name: "달램핏ㅇ임7",
@@ -40,12 +47,19 @@ export default function Page() {
   const router = useRouter();
   const queryClient = useQueryClient();
 
+
+  // 라운지 게시물 필터링을 위해 id 세팅 , 추후 다른곳에서도 id 사용여지가있을것같아서 일단 전역으로 두었는데 상황에 따라서 전역관리 안해도 될것같으면 제외하는걸로
+  const userId = useAuthStore((state) => state.userId);
+  const setUserId = useAuthStore((state) => state.setUserId);
+
+
   const { mutate: toggleFavorite } = useMutation({
     mutationFn: (meetingId: number) => deleteFavorites(meetingId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["favorites"] });
     },
   });
+
 
   const { data: user } = useQuery({
     queryKey: ["user"],
@@ -68,18 +82,24 @@ export default function Page() {
     },
   });
 
+
+  useEffect(() => {
+    if (user?.id) setUserId(user.id);
+  }, [user]);
+
+
   return (
     <div className="w-full flex-1 bg-gray-50 pt-6 pb-20 md:pt-10 lg:pt-[48px]">
       <div className="mx-auto w-full max-w-[1280px] px-4 md:px-6 lg:px-8">
         {/*<div onClick={() => postMeetType()}>모임 종류 생성</div>*/}
         {/*<div onClick={() => updateFavorites(698)}>찜 추가</div>*/}
         {/*<div onClick={() => createMeeting(mockMeeting)}>모임생성</div>*/}
-        <h1 className="mb-4 ml-2 cursor-pointer text-xl font-bold text-gray-900 md:mb-8 md:text-2xl lg:mb-10 lg:text-[32px]">
-          마이페이지
-        </h1>
 
         <div className="flex flex-col gap-5 md:gap-10 lg:flex-row lg:items-start lg:gap-[56px]">
-          <section className="w-full shrink-0 lg:w-[282px]">
+          <section className="mt-0 w-full shrink-0 lg:mt-[22px] lg:w-[282px]">
+            <h1 className="mb-4 ml-2 cursor-pointer text-xl font-bold text-gray-900 md:mb-8 md:text-2xl lg:mb-10 lg:text-[32px]">
+              마이페이지
+            </h1>
             <article className="border-main-green-400 bg-main-green-100 flex h-[100px] w-full shrink-0 items-center rounded-[24px] border px-4 md:h-[124px] md:px-6 lg:h-[370px] lg:w-[282px] lg:flex-col lg:justify-center lg:py-10">
               <div className="flex shrink-0 items-center gap-2 lg:flex-col lg:gap-6">
                 <div className="relative size-[30px] overflow-hidden rounded-full sm:size-[36px] lg:size-[114px]">
@@ -128,7 +148,7 @@ export default function Page() {
 
           <section className="flex min-w-0 flex-1 flex-col">
             <TabCommon>
-              <TabsContent value="liked" className="mt-6 md:mt-[42px]">
+              <TabsContent value="liked" className="mt-6 md:mt-[32px]">
                 {favoritesList?.map((item: any) => (
                   <DetailCardCommon
                     key={item.id}
@@ -138,10 +158,15 @@ export default function Page() {
                     imageSrc={item.meeting.image}
                     capacity={item.meeting.capacity}
                     participantCount={item.meeting.participantCount}
+                    defaultLiked={true}
+                    onDetailClick={() =>
+                      router.push(`/meeting/${item.meetingId}`)
+                    }
+                    onHeartClick={() => toggleFavorite(item.meetingId)}
                   />
                 ))}
               </TabsContent>
-              <TabsContent value="created" className="mt-6 md:mt-[42px]">
+              <TabsContent value="created" className="mt-6 md:mt-[32px]">
                 {meetList?.map((item: any) => (
                   <DetailCardCommon
                     key={item.id}
@@ -151,11 +176,15 @@ export default function Page() {
                     imageSrc={item.image}
                     capacity={item.capacity}
                     participantCount={item.participantCount}
+                    showLikeBtn={false}
+                    onDetailClick={() => router.push(`/meeting/${item.id}`)}
                   />
                 ))}
               </TabsContent>
-              <TabsContent value="lounge" className="md:mt-[42px]">
-                <LoungePostListCommon />
+              <TabsContent value="lounge" className="md:mt-[32px]">
+                <LoungePostListCommon
+                  filterFn={(post) => post.author.id === userId}
+                />
               </TabsContent>
             </TabCommon>
           </section>

--- a/src/components/common/LoungePostCardCommon.tsx
+++ b/src/components/common/LoungePostCardCommon.tsx
@@ -43,6 +43,7 @@ export default function LoungePostCardCommon({
             alt="게시물 썸네일"
             fill
             className="object-cover"
+            unoptimized
           />
         </div>
       ) : (
@@ -61,6 +62,7 @@ export default function LoungePostCardCommon({
               alt="게시물 썸네일"
               fill
               className="object-cover"
+              unoptimized
             />
           </div>
         ) : (
@@ -80,6 +82,7 @@ export default function LoungePostCardCommon({
                 width={24}
                 height={24}
                 className="rounded-full"
+                unoptimized
               />
             </div>
             <span>
@@ -95,6 +98,7 @@ export default function LoungePostCardCommon({
                 alt="좋아요 아이콘"
                 width={15}
                 height={15}
+                unoptimized
               />
               {likeCount}
             </span>
@@ -104,6 +108,7 @@ export default function LoungePostCardCommon({
                 alt="댓글 아이콘"
                 width={15}
                 height={15}
+                unoptimized
               />
               {commentCount}
             </span>

--- a/src/components/common/LoungePostListCommon.tsx
+++ b/src/components/common/LoungePostListCommon.tsx
@@ -6,20 +6,29 @@ import { getPosts } from "@/api/posts";
 import { Posts } from "@/types";
 import { useRouter } from "next/navigation";
 
-export default function LoungePostListCommon() {
+interface Props {
+  filterFn?: (post: Posts) => boolean;
+}
 
+export default function LoungePostListCommon({ filterFn }: Props) {
   const router = useRouter();
 
+  // 원래는 백엔드측에서 필터걸어서 주는 형식이어야 하지만 프론트쪽에서 제한적으로 적용하는것이기 떄문에 최근 게시물 100개중에서만 나의 게시물 찾아오는 형식으로 제한적 구현
+  const size = filterFn ? 100 : 10;
 
   const { data: loungeList } = useQuery({
-    queryKey: ["posts"],
-    queryFn: getPosts,
+    queryKey: ["posts", size],
+    queryFn: () => getPosts({ size }),
   });
+
+  // 해당 컴포넌트가 라운지쪽과 마이페이지에서 사용하는데 필터링 하는 기준이 각각 달라서 외부에서 필터링 기준만 주입하는 형식으로 진행
+  const list = filterFn ? loungeList?.filter(filterFn) : loungeList;
+
 
   return (
     <div className="flex w-full flex-col rounded-[24px] bg-white px-6 py-2 shadow-[0_2px_12px_rgba(0,0,0,0.04)] md:p-8">
       <div className="flex flex-col md:gap-12">
-        {loungeList?.map((post: Posts) => (
+        {list?.map((post: Posts) => (
           <LoungePostCardCommon
             key={post.id}
             id={post.id}

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -1,0 +1,11 @@
+import { create } from "zustand";
+
+interface AuthState {
+  userId: number | null;
+  setUserId: (id: number) => void;
+}
+
+export const useAuthStore = create<AuthState>((set) => ({
+  userId: null,
+  setUserId: (id) => set({ userId: id }),
+}));


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> PR과 연관된 이슈 번호를 작성해주세요.

- close: #56 

## 🪄 작업 내용

> 해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.
> 뷰 작업 내용이 포함되었을 경우 사진 혹은 동영상 파일 첨부를 부탁드립니다!

- 마이페이지의 라운지게시물 내가 쓴 게시물만 가져오기 구현 완료 
- 스토어 추가해서 일단 전역메모리로 userId 가지게 하긴했는데 차후 다른 방식으로 id 보유하는 형식 필요 , 
- LoungePoistListCommon 최대한 재사용 가능하게 재구성 , 외부에서 필터 조건 주입하는 형식으로 구현 

## 💖 리뷰 요청사항

> 특별히 봐주셨으면 하는 부분, 나 좀 잘했다 하는 부분! 기타 당부의 말씀 등 자유롭게 작성해주세요.

-
