### PR TITLE
[FEAT] 로그인 로직 구현

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -3,10 +3,24 @@ import axios from "axios";
 const BASE_URL = process.env.NEXT_PUBLIC_API_URL;
 
 export async function getRefresh(
-  refreshToken: string
+  refreshToken: string,
 ): Promise<{ accessToken: string; refreshToken: string }> {
   const { data } = await axios.post(`${BASE_URL}/auth/refresh`, {
     refreshToken,
   });
   return data;
+}
+
+export interface LoginResult {
+  ok: boolean;
+}
+
+export async function loginUser(data: {
+  email: string;
+  password: string;
+}): Promise<LoginResult> {
+  const res = await axios.post("/api/login", data, {
+    withCredentials: true,
+  });
+  return res.data;
 }

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,26 +1,45 @@
-'use client'
+"use client";
+import { useLogin } from "@/hooks/useLogin";
 import { InputCommon } from "@/components/common/InputCommon";
 import { BtnCommon } from "@/components/common/BtnCommon";
-import { useState } from "react";
-import Link from "next/link"
+import { FormEvent, useState } from "react";
+import Link from "next/link";
 import Image from "next/image";
+import { useRouter } from "next/navigation";
 import kakaoIcon from "@/assets/icon/kakao/kakao-logo.svg";
 import googleIcon from "@/assets/icon/google/google-logo.svg";
 
 export default function Login() {
-  const [name, setName] = useState("");
+  const { handleLogin, isLoading, error } = useLogin();
+  const router = useRouter();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
-  const [passwordConfirm, setPasswordConfirm] = useState("");
-  const [introduce, setIntroduce] = useState("");
+
+  const onSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    const res = await handleLogin(email, password); // 로그인 요청 실행
+
+    if (res?.ok) {
+      router.push("/");
+    }
+  };
 
   return (
     <>
-      <section className="py-6 md:py-25 min-h-[calc(100vh-48px)] md:min-h-[calc(100vh-88px)] flex items-center bg-[#F6F7F9]" aria-labelledby="login-header">
-        <div className="px-4 md:px-0 md:max-w-142 w-full md:mx-auto">
-          <div className="py-6 px-4 md:py-10 md:px-16 bg-white rounded-xl md:rounded-[40px] border">
-            <h1 id="login-header" className="text-center text-base md:text-2xl text-gray-900 font-semibold">로그인</h1>
-            <form className="flex flex-col gap-6 pt-10">
+      <section
+        className="flex min-h-[calc(100vh-48px)] items-center bg-[#F6F7F9] py-6 md:min-h-[calc(100vh-88px)] md:py-25"
+        aria-labelledby="login-header"
+      >
+        <div className="w-full px-4 md:mx-auto md:max-w-142 md:px-0">
+          <div className="rounded-xl border bg-white px-4 py-6 md:rounded-[40px] md:px-16 md:py-10">
+            <h1
+              id="login-header"
+              className="text-center text-base font-semibold text-gray-900 md:text-2xl"
+            >
+              로그인
+            </h1>
+            <form className="flex flex-col gap-6 pt-10" onSubmit={onSubmit}>
               <InputCommon
                 label="이메일"
                 type="email"
@@ -28,7 +47,7 @@ export default function Login() {
                 placeholder="이메일을 입력해주세요."
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
-                onClear={() => setEmail('')}
+                onClear={() => setEmail("")}
                 inputSize={"sm"}
                 className="md:text-base"
               />
@@ -39,30 +58,58 @@ export default function Login() {
                 placeholder="비밀번호를 입력해주세요."
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
-                onClear={() => setPassword('')}
+                onClear={() => setPassword("")}
                 inputSize={"sm"}
                 className="md:text-base"
               />
-              <BtnCommon variant={"default"} size={"md"} type="submit" children="로그인" />
+              <BtnCommon variant={"default"} size={"md"} type="submit">
+                {isLoading ? "로그인 중..." : "로그인"}
+              </BtnCommon>
             </form>
-            <div className="flex items-center gap-4 mt-8 mb-6">
-              <div className="flex-1 h-px bg-gray-300"></div>
-              <p className="shrink text-[15px] font-medium text-gray-500">SNS 계정으로 회원가입</p>
-              <div className="flex-1 h-px bg-gray-300"></div>
+            {error && <p className="mt-4 text-sm text-red-500">{error}</p>}
+            <div className="mt-8 mb-6 flex items-center gap-4">
+              <div className="h-px flex-1 bg-gray-300"></div>
+              <p className="shrink text-[15px] font-medium text-gray-500">
+                SNS 계정으로 회원가입
+              </p>
+              <div className="h-px flex-1 bg-gray-300"></div>
             </div>
-            <div className="flex flex-col md:flex-row gap-3">
-              <BtnCommon className={`bg-white border md:w-1/2 border-gray-200 text-gray-800 text-base`} size={"fixedSize"}>
-                <Image src={googleIcon} width="24" height="24" alt="구글 아이콘" />
+            <div className="flex flex-col gap-3 md:flex-row">
+              <BtnCommon
+                className={`border border-gray-200 bg-white text-base text-gray-800 md:w-1/2`}
+                size={"fixedSize"}
+              >
+                <Image
+                  src={googleIcon}
+                  width="24"
+                  height="24"
+                  alt="구글 아이콘"
+                />
                 <p className="ml-3">구글로 계속하기</p>
               </BtnCommon>
-              <BtnCommon className="bg-[#FFEE01] md:w-1/2 text-gray-800 text-base" size={"fixedSize"}>
-                <Image src={kakaoIcon} width="24" height="24" alt="카카오 아이콘" />
+              <BtnCommon
+                className="bg-[#FFEE01] text-base text-gray-800 md:w-1/2"
+                size={"fixedSize"}
+              >
+                <Image
+                  src={kakaoIcon}
+                  width="24"
+                  height="24"
+                  alt="카카오 아이콘"
+                />
                 <p className="ml-3">카카오로 계속하기</p>
               </BtnCommon>
             </div>
-            <div className="flex gap-1 justify-center items-center mt-8">
-              <p className="text-sm font-regular text-gray-800">같이달램이 처음이신가요?</p>
-              <Link href="/signup" className="text-sm text-green-600 font-semibold underline">회원가입</Link>
+            <div className="mt-8 flex items-center justify-center gap-1">
+              <p className="font-regular text-sm text-gray-800">
+                같이달램이 처음이신가요?
+              </p>
+              <Link
+                href="/signup"
+                className="text-sm font-semibold text-green-600 underline"
+              >
+                회원가입
+              </Link>
             </div>
           </div>
         </div>

--- a/src/app/api/login/route.ts
+++ b/src/app/api/login/route.ts
@@ -1,0 +1,63 @@
+import axios from "axios";
+import { NextResponse } from "next/server";
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL;
+
+const ACCESS_TOKEN_MAX_AGE = 60 * 15;
+const REFRESH_TOKEN_MAX_AGE = 60 * 60 * 24 * 7;
+
+interface LoginRequestBody {
+  email: string;
+  password: string;
+}
+
+interface LoginResponseBody {
+  accessToken: string;
+  refreshToken: string;
+}
+
+export async function POST(request: Request) {
+  const body = (await request.json()) as LoginRequestBody;
+  try {
+    const { data: loginData } = await axios.post<LoginResponseBody>(
+      `${API_BASE_URL}/auth/login`,
+      body,
+      {
+        headers: {
+          "Content-Type": "application/json",
+        },
+      },
+    );
+    const response = NextResponse.json({
+      ok: true,
+    });
+
+    response.cookies.set("accessToken", loginData.accessToken, {
+      httpOnly: true,
+      path: "/",
+      sameSite: "strict",
+      secure: process.env.NODE_ENV === "production",
+      maxAge: ACCESS_TOKEN_MAX_AGE,
+    });
+    response.cookies.set("refreshToken", loginData.refreshToken, {
+      httpOnly: true,
+      path: "/",
+      sameSite: "strict",
+      secure: process.env.NODE_ENV === "production",
+      maxAge: REFRESH_TOKEN_MAX_AGE,
+    });
+
+    return response;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      return NextResponse.json(
+        error.response?.data ?? { message: "로그인 실패" },
+        {
+          status: error.response?.status ?? 500,
+        },
+      );
+    }
+
+    return NextResponse.json({ message: "로그인 실패" }, { status: 500 });
+  }
+}

--- a/src/hooks/useLogin.ts
+++ b/src/hooks/useLogin.ts
@@ -1,0 +1,28 @@
+"use client";
+
+import { loginUser, type LoginResult } from "@/api/auth";
+import { useState } from "react";
+
+export function useLogin() {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<null | string>(null);
+
+  const handleLogin = async (
+    email: string,
+    password: string,
+  ): Promise<LoginResult | undefined> => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const result = await loginUser({ email, password });
+      return result;
+    } catch {
+      setError("로그인 실패. 다시 시도해주세요.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return { handleLogin, isLoading, error };
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+export function middleware(request: NextRequest) {
+  // 1. 쿠키에서 토큰을 꺼내봅니다.
+  const token = request.cookies.get("accessToken")?.value;
+
+  // 2. 만약 토큰이 없는데 보호된 페이지로 가려고 한다면?
+  const protectedPaths = ["/mypage", "/lounge", "/meeting", "/users"];
+  const isProtected = protectedPaths.some((path) =>
+    request.nextUrl.pathname.startsWith(path),
+  );
+
+  if (!token && isProtected) {
+    // 3. 로그인 페이지로 튕겨냅니다.
+    return NextResponse.redirect(new URL("/login", request.url));
+  }
+
+  // 토큰이 있거나, 공개된 페이지라면 그대로 통과!
+  return NextResponse.next();
+}
+
+// 이 미들웨어가 작동할 주소들 (불필요한 곳은 검사 안 함)
+export const config = {
+  matcher: [
+    "/mypage/:path*",
+    "/lounge/:path*",
+    "/meeting/:path*",
+    "/users/:path*",
+    "/dashboard/:path*",
+  ],
+};


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> PR과 연관된 이슈 번호를 작성해주세요.

- close: #42 

## 🪄 작업 내용

> 해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.
> 뷰 작업 내용이 포함되었을 경우 사진 혹은 동영상 파일 첨부를 부탁드립니다!

- 로그인 → POST → 서버 응답 → 쿠키 저장
1. 사용자가 로그인 폼에서 이메일/비밀번호를 입력한다.
2. 로그인 페이지가 handleLogin()을 호출한다.
3. 클라이언트 API 함수가 POST /api/login을 호출한다.
4. Next.js Route Handler가 이 요청을 받아 실제 백엔드 로그인 API로 전달한다.
5. 백엔드가 accessToken, refreshToken을 응답한다.
6. Next.js 서버가 이 토큰들을 쿠키로 저장한다.
7. 클라이언트는 성공 여부만 받고 메인 페이지 /로 이동한다.
<img width="832" height="238" alt="image" src="https://github.com/user-attachments/assets/0228e3e4-7ce6-48cb-9e72-677f73062769" />

## 💖 리뷰 요청사항

> 특별히 봐주셨으면 하는 부분, 나 좀 잘했다 하는 부분! 기타 당부의 말씀 등 자유롭게 작성해주세요.

-
