### PR TITLE
[FEAT] 라운지 생성 페이지 레이아웃 및 기본 기능 구현

### DIFF
--- a/src/app/lounge/create/page.tsx
+++ b/src/app/lounge/create/page.tsx
@@ -1,3 +1,112 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import {
+  Bold,
+  Italic,
+  Underline,
+  Strikethrough,
+  Link2,
+  Image as ImageIcon,
+  List,
+  ListOrdered,
+  AlignLeft,
+  AlignCenter,
+  AlignRight,
+  AlignJustify,
+} from "lucide-react";
+
+import { BtnCommon } from "@/components/common/BtnCommon";
+
 export default function LoungeCreatePage() {
-  return <div>라운지 게시물 생성</div>;
+  const router = useRouter();
+  const [title, setTitle] = useState("");
+  const [content, setContent] = useState("");
+
+  const TITLE_MAX_LENGTH = 30;
+
+  const titleLength = title.length;
+  const contentWithSpaces = content.length;
+  const contentWithoutSpaces = content.replace(/\s/g, "").length;
+
+  const handleSubmit = async () => {
+    if (!title.trim() || !content.trim()) {
+      alert("제목과 내용을 모두 입력해주세요.");
+      return;
+    }
+    // TODO: API 연동 로직 (POST /posts)
+    // 성공 시 이동: router.push("/lounge");
+  };
+
+  const toolbarIconClass =
+    "size-4 sm:size-5 text-gray-500 hover:text-gray-900 cursor-pointer transition-colors";
+
+  return (
+    <div className="min-h-screen w-full pt-6 pb-20 sm:pt-10 lg:pt-[48px]">
+      <div className="mx-auto w-full max-w-[860px] px-4 sm:px-6 lg:px-8">
+        <div className="mb-8 flex !h-[40px] items-center justify-between gap-6 sm:!h-[50px] lg:mb-10">
+          <div className="relative flex-1 pl-2">
+            <input
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              maxLength={TITLE_MAX_LENGTH}
+              placeholder="제목을 입력해주세요"
+              className="w-full border-b-2 border-gray-300 bg-transparent pt-2 pr-11 pb-1 text-lg font-bold text-gray-900 transition-colors placeholder:text-gray-300 focus:border-green-500 focus:outline-none sm:pb-3 sm:text-2xl lg:text-3xl"
+            />
+            <span className="absolute right-0 bottom-2 text-sm text-gray-400 sm:bottom-4">
+              <span className={titleLength > 0 ? "text-green-500" : ""}>
+                {titleLength}
+              </span>
+              /{TITLE_MAX_LENGTH}
+            </span>
+          </div>
+
+          <BtnCommon
+            onClick={handleSubmit}
+            className="!h-[40px] flex-0 !rounded-[12px] px-4 text-sm font-semibold sm:!h-[50px] sm:px-8 sm:text-lg"
+          >
+            등록
+          </BtnCommon>
+        </div>
+
+        <div className="flex min-h-[500px] flex-col rounded-[24px] bg-white p-4 shadow-[0_2px_12px_rgba(0,0,0,0.04)] sm:min-h-[600px] sm:p-6 md:p-8">
+          <div className="scrollbar-hide mb-4 flex items-center justify-between overflow-x-auto border-b border-gray-200 pb-4 sm:mb-6 sm:pb-5">
+            <div className="flex min-w-max items-center gap-3 pr-4 sm:gap-4.5">
+              <Bold className={toolbarIconClass} />
+              <Italic className={toolbarIconClass} />
+              <Underline className={toolbarIconClass} />
+              <Strikethrough className={toolbarIconClass} />
+              <div className="mx-1 h-4 w-px bg-gray-200 sm:mx-0" />{" "}
+              <Link2 className={toolbarIconClass} />
+              <ImageIcon className={toolbarIconClass} />
+              <div className="mx-1 h-4 w-px bg-gray-200 sm:mx-0" />{" "}
+              <ListOrdered className={toolbarIconClass} />
+              <List className={toolbarIconClass} />
+            </div>
+
+            <div className="flex min-w-max items-center gap-3 border-l border-gray-100 pl-4 sm:gap-4.5 sm:border-none">
+              <AlignLeft className={toolbarIconClass} />
+              <AlignCenter className={toolbarIconClass} />
+              <AlignRight className={toolbarIconClass} />
+              <AlignJustify className={toolbarIconClass} />
+            </div>
+          </div>
+
+          <textarea
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+            placeholder="본문 내용을 입력해주세요"
+            className="w-full flex-1 resize-none text-base leading-relaxed text-gray-800 placeholder:text-gray-300 focus:outline-none"
+          />
+
+          <div className="mt-6 border-t border-gray-100 pt-5 text-right text-sm font-medium text-gray-500">
+            공백포함 : 총 {contentWithSpaces.toLocaleString()}자 | 공백제외 : 총{" "}
+            {contentWithoutSpaces.toLocaleString()}자
+          </div>
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/src/components/common/HotListCardCommon.tsx
+++ b/src/components/common/HotListCardCommon.tsx
@@ -15,7 +15,7 @@ import { getRelativeTime } from "@/lib/date";
 
 interface HotListCardCommonProps {
   title?: string;
-  date?: string | Date; // ⭐️ 서버에서 string(createdAt)으로 오니까 타입을 확장해줍니다.
+  date?: string | Date;
   imageSrc?: string | null;
   thumbsUp?: number;
   comment?: number;
@@ -30,8 +30,6 @@ export function HotListCardCommon({
   thumbsUp = 0,
   comment = 0,
 }: HotListCardCommonProps) {
-  const displayDate = typeof date === "string" ? new Date(date) : date;
-
   return (
     <Card
       className="h-fit w-[162px] shrink-0 cursor-pointer gap-0! rounded-[24px] bg-gray-50 pt-0! pb-0! ring-0! sm:w-[300px]"


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> PR과 연관된 이슈 번호를 작성해주세요.

- close: #72 

## 🪄 작업 내용

> 해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.
> 뷰 작업 내용이 포함되었을 경우 사진 혹은 동영상 파일 첨부를 부탁드립니다!

- 라운지 생성 레이아웃 (반응형)
- 모바일에서는 툴바 가로형 스크롤
- 제목 글자수 제한
- 본문 글자수 계산
<img width="381" height="597" alt="스크린샷 2026-03-18 오전 11 50 40" src="https://github.com/user-attachments/assets/fcdb2490-7cd7-43d3-9c38-e432267ef82c" />
<img width="587" height="597" alt="스크린샷 2026-03-18 오전 11 50 57" src="https://github.com/user-attachments/assets/53a768e7-4554-4a54-8689-397dc40030ba" />
<img width="587" height="442" alt="스크린샷 2026-03-18 오전 11 51 18" src="https://github.com/user-attachments/assets/d58f57e5-f5b9-4c5e-814b-98020cf4f14a" />


## 💖 리뷰 요청사항

> 특별히 봐주셨으면 하는 부분, 나 좀 잘했다 하는 부분! 기타 당부의 말씀 등 자유롭게 작성해주세요.

- 링크 기반 정보 게시물임을 감안하여 툴바에 기능 아이콘(링크, 숫자 정렬 등) 추가(추후 기능 연결)
