### PR TITLE
[FEAT] axios interceptor 수정

### DIFF
--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -1,34 +1,72 @@
 import axios from "axios";
+import { getCookie, setCookie, deleteCookie } from "cookies-next";
 
 const axiosInstance = axios.create({
   baseURL: process.env.NEXT_PUBLIC_API_URL,
 });
 
-// 요청마다 토큰 자동 추가
+// 1. 요청 인터셉터: 신분증(토큰)을 헤더에 실어주는 비서 역할
 axiosInstance.interceptors.request.use((config) => {
-  const token = localStorage.getItem("token");
-  if (token) config.headers.Authorization = `Bearer ${token}`;
+  // 로그인, 회원가입 등 토큰이 필요 없는 경로는 패스
+  const skipList = ["/auth/login", "/auth/signup"];
+  if (skipList.some((url) => config.url?.includes(url))) {
+    return config;
+  }
+
+  const token = getCookie("accessToken");
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
   return config;
 });
 
-// 401 시 리프레시 후 재시도
+// 2. 응답 인터셉터: 서버가 "너 신분증 만료됐어(401)"라고 할 때 수습
 axiosInstance.interceptors.response.use(
   (res) => res,
   async (error) => {
-    const originalRequest = error.config;
-    if (error.response?.status === 401 && !originalRequest._retry) {
-      originalRequest._retry = true;
-      const refresh = localStorage.getItem("refresh");
-      if (!refresh) return Promise.reject(error);
+    const originalRequest = error.config; //실패한 원래 요청 정보 -> 이거 채가오는거
 
-      const { data } = await axios.post(
-        `${process.env.NEXT_PUBLIC_API_URL}/auth/refresh`,
-        { refreshToken: refresh },
-      );
-      localStorage.setItem("token", data.accessToken);
-      localStorage.setItem("refresh", data.refreshToken);
-      originalRequest.headers.Authorization = `Bearer ${data.accessToken}`;
-      return axiosInstance(originalRequest);
+    // 401 에러(인증 실패)가 났고, 아직 재시도를 안 했다면
+    if (error.response?.status === 401 && !originalRequest._retry) {
+      originalRequest._retry = true; //재시도 중임 알리는 플래그
+
+      const refreshToken = getCookie("refreshToken");
+
+      // 리프레시 토큰이 없으면 그냥 로그아웃 처리
+      if (!refreshToken) {
+        // 클라이언트 사이드 로그아웃 로직 (예: 쿠키 삭제 및 이동)
+        deleteCookie("accessToken");
+        deleteCookie("refreshToken");
+        if (typeof window !== "undefined") {
+          window.location.href = "/login";
+        }
+        return Promise.reject(error);
+      }
+
+      try {
+        // 서버에 토큰 갱신 요청 (API 검증 단계)
+        const { data } = await axios.post(
+          `${process.env.NEXT_PUBLIC_API_URL}/auth/refresh`,
+          { refreshToken },
+        );
+
+        // 새 토큰 저장
+        setCookie("accessToken", data.accessToken);
+        if (data.refreshToken) setCookie("refreshToken", data.refreshToken);
+
+        // 실패했던 원래 API 요청을 다시 시도
+        originalRequest.headers.Authorization = `Bearer ${data.accessToken}`;
+        return axiosInstance(originalRequest);
+      } catch (refreshError) {
+        // 리프레시 토큰마저 만료된 경우 (진짜 로그아웃)
+        deleteCookie("accessToken");
+        deleteCookie("refreshToken");
+        if (typeof window !== "undefined") {
+          // alert("세션이 만료되었습니다. 다시 로그인해주세요.");
+          window.location.href = "/login";
+        }
+        return Promise.reject(refreshError);
+      }
     }
     return Promise.reject(error);
   },

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,123 +1,50 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
+import axios from "axios";
 
-// 토큰 만료 시간 상수
-const ACCESS_TOKEN_MAX_AGE = 60 * 15; // 15분
+// 쿠키 만료 시간 (초 단위)
+const ACCESS_TOKEN_MAX_AGE = 60 * 15;
 const REFRESH_TOKEN_MAX_AGE = 60 * 60 * 24 * 7;
-
-// 보호 경로 목록
-const protectedPaths = [
-  "/lounge",
-  "/meetings",
-  "/users",
-  "/my-meetings",
-  "/ranking",
-];
-
-// 로그인 리다이렉트 처리
-function redirectToLogin(request: NextRequest) {
-  return NextResponse.redirect(new URL("/login", request.url));
-}
-
-// 보호 경로 확인
-function isProtectedPath(pathname: string) {
-  return protectedPaths.some((path) => pathname.startsWith(path));
-}
-
-// JWT payload 디코딩
-function decodeJwtPayload(token: string) {
-  const [, payload] = token.split(".");
-  if (!payload) return null;
-
-  try {
-    // base64url 형식 보정
-    const normalized = payload.replace(/-/g, "+").replace(/_/g, "/");
-    const padded = normalized.padEnd(
-      normalized.length + ((4 - (normalized.length % 4)) % 4),
-      "=",
-    );
-
-    return JSON.parse(atob(padded)) as { exp?: number };
-  } catch {
-    return null;
-  }
-}
-
-// 토큰 만료 여부 확인
-function isTokenExpired(token: string) {
-  const payload = decodeJwtPayload(token);
-
-  if (!payload?.exp) {
-    return true;
-  }
-
-  return payload.exp <= Math.floor(Date.now() / 1000);
-}
 
 export async function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
+  // console.log(process.env.NEXT_RUNTIME);
 
-  // 공개 경로 통과
-  if (!isProtectedPath(pathname)) {
-    return NextResponse.next();
-  }
-
-  // 쿠키 토큰 조회
+  // 쿠키에서 토큰 조회
   const accessToken = request.cookies.get("accessToken")?.value;
   const refreshToken = request.cookies.get("refreshToken")?.value;
 
-  // 유효한 액세스 토큰 통과
-  if (accessToken && !isTokenExpired(accessToken)) {
+  // 1. 액세스 토큰이 있으면 일단 통과 (유효성 검증은 API 레이어의 Axios가 담당)
+  if (accessToken) {
     return NextResponse.next();
   }
 
-  // 리프레시 토큰 부재 처리
+  // 2. 액세스 토큰이 없는데 리프레시 토큰도 없다면? 바로 로그인행
   if (!refreshToken) {
-    return redirectToLogin(request);
+    return NextResponse.redirect(new URL("/login", request.url));
   }
 
+  // 3. 액세스 토큰이 없지만 리프레시 토큰은 있는 경우 -> 토큰 갱신 시도 (라우팅 가드)
   try {
-    // 토큰 재발급 요청
-    const refreshResponse = await fetch(
+    // 멘토님 조언대로 axios 사용 (단, 절대 경로 필요)
+    const { data } = await axios.post(
       `${process.env.NEXT_PUBLIC_API_URL}/auth/refresh`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ refreshToken }),
-      },
+      { refreshToken },
     );
 
-    // 재발급 실패 처리
-    if (!refreshResponse.ok) {
-      return redirectToLogin(request);
-    }
-
-    // 재발급 응답 파싱
-    const data = (await refreshResponse.json()) as {
-      accessToken?: string;
-      refreshToken?: string;
-    };
-
-    // 액세스 토큰 검증
-    if (!data.accessToken) {
-      return redirectToLogin(request);
-    }
-
-    // 응답 객체 생성
     const response = NextResponse.next();
 
-    // 액세스 토큰 쿠키 갱신
-    response.cookies.set("accessToken", data.accessToken, {
-      httpOnly: true,
-      path: "/",
-      sameSite: "strict",
-      secure: process.env.NODE_ENV === "production",
-      maxAge: ACCESS_TOKEN_MAX_AGE,
-    });
+    // 새 토큰 쿠키 세팅
+    if (data.accessToken) {
+      response.cookies.set("accessToken", data.accessToken, {
+        httpOnly: true,
+        path: "/",
+        sameSite: "strict",
+        secure: process.env.NODE_ENV === "production",
+        maxAge: ACCESS_TOKEN_MAX_AGE,
+      });
+    }
 
-    // 리프레시 토큰 쿠키 갱신
     if (data.refreshToken) {
       response.cookies.set("refreshToken", data.refreshToken, {
         httpOnly: true,
@@ -129,13 +56,14 @@ export async function proxy(request: NextRequest) {
     }
 
     return response;
-  } catch {
-    // 예외 상황 처리
-    return redirectToLogin(request);
+  } catch (error) {
+    // 갱신 실패 시 (리프레시 토큰 만료 등) 로그인 페이지로
+    console.error("Middleware refresh error:", error);
+    return NextResponse.redirect(new URL("/login", request.url));
   }
 }
 
-// 프록시 적용 경로 설정
+// 보호할 경로 설정 (matcher 활용으로 코드 내 protectedPaths 배열 생략 가능)
 export const config = {
   matcher: [
     "/lounge/:path*",


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> PR과 연관된 이슈 번호를 작성해주세요.

- close: #74 

## 🪄 작업 내용

> 해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.
> 뷰 작업 내용이 포함되었을 경우 사진 혹은 동영상 파일 첨부를 부탁드립니다!

- 미들웨어 인증 로직 최적화 및 Runtime 변경

- Silent Refresh 구현: 페이지 진입 시 accessToken이 없더라도 refreshToken이 존재하면 서버와 통신하여 자동으로 토큰을 갱신하는 로직을 구축
- 라우팅 가드 강화: matcher를 통해 인증이 필요한 경로(/lounge, /meetings 등)를 지정하고, 유효한 토큰이 없을 경우 /login으로 리다이렉트되도록 설정

- Axios 인터셉터를 통한 이중 방어막 구축
- 쿠키 관리 방식 단일화
localStorage 대신 cookies-next 라이브러리를 도입하여 서버(미들웨어)와 클라이언트(Axios)가 동일한 쿠키 데이터를 공유하고 제어할 수 있도록 동기화

## 💖 리뷰 요청사항

> 특별히 봐주셨으면 하는 부분, 나 좀 잘했다 하는 부분! 기타 당부의 말씀 등 자유롭게 작성해주세요.

-
