### PR TITLE
[FEAT] 모임 상세 상단 액션 영역 개편

### DIFF
--- a/src/app/meetings/[id]/components/MeetingDetailContent.tsx
+++ b/src/app/meetings/[id]/components/MeetingDetailContent.tsx
@@ -1,19 +1,19 @@
 "use client";
 
 import { useState } from "react";
+import { AlertCircle } from "lucide-react";
 import { MeetingDetailView } from "@/app/meetings/[id]/components/MeetingDetailView";
-
-import { JoinedMeeting, User } from "@/types";
-import { useMeetingDetailQueries, useMeetingDetailMutations } from "@/hooks";
-import {
+import { useMeetingDetailMutations, useMeetingDetailQueries } from "@/hooks";
+import type {
+  MeetingActionState,
   MeetingDetailApiData,
+  MeetingDetailContentProps,
   MeetingDetailData,
   MeetingListItemApiData,
   MeetingParticipant,
   RecommendedMeetingItem,
-  MeetingDetailContentProps,
+  User,
 } from "@/types";
-import { AlertCircle } from "lucide-react";
 
 const hasRecruitmentOpen = (
   meeting: Pick<
@@ -43,49 +43,43 @@ const toRecommendedMeetingItem = (
   dateTime: meeting.dateTime,
 });
 
-interface GetActionLabelProps {
-  isLoggedIn: boolean;
-  isHost: boolean;
-  isComplete: boolean;
-  isClosed: boolean;
-  hasAttended: boolean;
-  isJoined: boolean;
-}
-
-const getActionLabel = ({
+const getActionState = ({
   isLoggedIn,
-  isHost,
-  isComplete,
-  isClosed,
+  isParticipant,
+  isCheckingAttendance,
   hasAttended,
-  isJoined,
-}: GetActionLabelProps) => {
-  if (!isLoggedIn) {
-    return isClosed || isComplete ? "모집 마감" : "참여하기";
+}: {
+  isLoggedIn: boolean;
+  isParticipant: boolean;
+  isCheckingAttendance: boolean;
+  hasAttended: boolean;
+}): MeetingActionState => {
+  if (!isLoggedIn) return "guest_join";
+  if (!isParticipant) return "joinable";
+  if (isCheckingAttendance) return "attendance_checking";
+  if (hasAttended) return "attendance_done";
+  return "attendance_ready";
+};
+
+const getActionUI = ({
+  actionState,
+  isCapacityFull,
+}: {
+  actionState: MeetingActionState;
+  isCapacityFull: boolean;
+}) => {
+  switch (actionState) {
+    case "guest_join":
+      return { label: "참여하기", disabled: false };
+    case "joinable":
+      return { label: "참여하기", disabled: isCapacityFull };
+    case "attendance_checking":
+      return { label: "출석 확인 중", disabled: true };
+    case "attendance_done":
+      return { label: "출석완료", disabled: true };
+    case "attendance_ready":
+      return { label: "출석하기", disabled: false };
   }
-
-  if (isHost) {
-    // closed = 사람 다찼따
-    if (isClosed) {
-      if (isComplete) {
-        // complete be 에서 내려주는 값
-        return hasAttended ? "출석 완료" : "출석하기";
-      } else {
-        return "모집 마감";
-      }
-    } else {
-      return "공유 하기";
-    }
-  }
-
-  if (isComplete) {
-    if (isJoined) return hasAttended ? "출석 완료" : "출석하기";
-    return "모집 마감";
-  }
-
-  if (isJoined) return "참여 취소하기";
-
-  return "참여하기";
 };
 
 export const getRecommendedMeetings = ({
@@ -161,33 +155,43 @@ const getIsJoined = ({
   );
 };
 
-const getIsLoggedIn = ({ user }: { user: User | null }) => Boolean(user);
-
 export const toMeetingDetailViewModel = ({
   detail,
   participants,
   recommendationCandidates,
   currentTimestamp,
   user,
-  isAuthLoading,
   hasAttended,
+  isCheckingAttendance,
 }: {
   detail: MeetingDetailApiData;
   participants: MeetingParticipant[];
   recommendationCandidates: MeetingListItemApiData[];
   currentTimestamp: number;
   user: User | null;
-  isAuthLoading: boolean;
   hasAttended: boolean;
+  isCheckingAttendance: boolean;
 }) => {
   const isHost = getIsHost(detail, user);
-  const isLoggedIn = getIsLoggedIn({ user });
+  const isLoggedIn = Boolean(user);
   const isJoined = getIsJoined({
     detail,
     participants,
     user,
     isHost,
     isLoggedIn,
+  });
+  const isParticipant = isHost || isJoined;
+  const isCapacityFull = detail.participantCount >= detail.capacity;
+  const actionState = getActionState({
+    isLoggedIn,
+    isParticipant,
+    isCheckingAttendance,
+    hasAttended,
+  });
+  const actionUI = getActionUI({
+    actionState,
+    isCapacityFull,
   });
 
   const recommendedMeetings = getRecommendedMeetings({
@@ -227,59 +231,30 @@ export const toMeetingDetailViewModel = ({
     recommendedMeetings,
   };
 
-  const isStarted = new Date(data.dateTime).getTime() <= currentTimestamp;
-
-  const canViewLink = isLoggedIn && isJoined;
-  const canWriteThread = isHost || (isLoggedIn && isJoined);
+  const canViewLink = isLoggedIn && isParticipant;
+  const canWriteThread = isLoggedIn && isParticipant;
+  const shouldShowShareButton = isLoggedIn && isParticipant;
   const shouldShowHostMenu = isHost;
-
-  const isComplete = detail.isCompleted;
-
-  function isMeetingClosed(detail: MeetingDetailApiData) {
-    const now = new Date();
-    const isRegistrationClosed = new Date(detail.registrationEnd) < now;
-    const isFull = detail.participantCount >= detail.capacity;
-
-    return isRegistrationClosed || isFull;
-  }
-
-  const isClosed = isMeetingClosed(detail);
-
-  const shouldShowClosedGuide =
-    isLoggedIn && !isHost && !isJoined && isClosed && !isStarted;
-
-  const actionLabel = getActionLabel({
-    isLoggedIn,
-    isHost,
-    isComplete,
-    isClosed,
-    hasAttended,
-    isJoined,
-  });
-
-
-
-  const isActionDisabled = () => {
-    if (actionLabel === "모집 마감" || actionLabel === "출석 완료") return true;
-    return false;
-  };
+  const shouldShowParticipantMenu = isJoined && !isHost;
   const linkGuideText = isLoggedIn
-    ? "모임에 참여하면 링크를 확인할 수 있습니다."
-    : "로그인 후 모임에 참여하면 링크를 확인할 수 있습니다.";
+    ? "모임에 참여하면 링크를 확인할 수 있어요."
+    : "로그인 후 모임에 참여하면 링크를 확인할 수 있어요.";
   const threadGuideText = isLoggedIn
-    ? "모임에 참여하면 스레드를 작성할 수 있습니다."
-    : "로그인 후 모임에 참여하면 스레드를 작성할 수 있습니다.";
+    ? "모임에 참여하면 스레드를 작성할 수 있어요."
+    : "로그인 후 모임에 참여하면 스레드를 작성할 수 있어요.";
 
   return {
-    actionLabel,
+    actionState,
+    actionLabel: actionUI.label,
     canViewLink,
     canWriteThread,
     data,
-    isActionDisabled,
+    isActionDisabled: actionUI.disabled,
     linkGuideText,
     participantAvatars: participants.map((participant) => participant.user),
-    shouldShowClosedGuide,
+    shouldShowShareButton,
     shouldShowHostMenu,
+    shouldShowParticipantMenu,
     threadGuideText,
   };
 };
@@ -295,6 +270,7 @@ export function MeetingDetailContent({
     user,
     isAuthLoading,
     hasAttended,
+    isCheckingAttendance,
     joinMutation,
     cancelJoinMutation,
     favoriteMutation,
@@ -316,7 +292,6 @@ export function MeetingDetailContent({
   const recommendationCandidates =
     recommendationCandidatesQuery.data?.data ?? [];
 
-  /* 💡 로딩 상태: 아카이브 테마의 부드러운 UI */
   if (detailQuery.isLoading || !detail) {
     return (
       <div className="flex min-h-[400px] w-full flex-col items-center justify-center rounded-[32px] border border-slate-50 bg-white p-12 shadow-sm">
@@ -334,7 +309,6 @@ export function MeetingDetailContent({
     return (
       <div className="flex min-h-[400px] w-full flex-col items-center justify-center rounded-[32px] border border-red-50 bg-red-50/30 p-12 text-center shadow-sm">
         <div className="mb-4 flex size-14 items-center justify-center rounded-full bg-red-100/50 text-red-500">
-          {/* 💡 Lucide 아이콘은 size 프롭을 지원합니다 */}
           <AlertCircle size={32} strokeWidth={2.5} />
         </div>
         <p className="text-lg font-black tracking-tighter text-slate-950">
@@ -353,40 +327,38 @@ export function MeetingDetailContent({
     recommendationCandidates,
     currentTimestamp,
     user,
-    isAuthLoading,
     hasAttended,
+    isCheckingAttendance,
   });
 
   return (
-    <>
-      <MeetingDetailView
-        data={viewModel.data}
-        participantAvatars={viewModel.participantAvatars}
-        isFavoritePending={favoriteMutation.isPending}
-        isJoinPending={
-          joinMutation.isPending ||
-          cancelJoinMutation.isPending ||
-          attendMutation.isPending
-        }
-        isAuthLoading={isAuthLoading}
-        actionLabel={viewModel.actionLabel}
-        isActionDisabled={viewModel.isActionDisabled()}
-        shouldShowHostMenu={viewModel.shouldShowHostMenu}
-        shouldShowClosedGuide={viewModel.shouldShowClosedGuide}
-        canViewLink={viewModel.canViewLink}
-        canWriteThread={viewModel.canWriteThread}
-        linkGuideText={viewModel.linkGuideText}
-        threadGuideText={viewModel.threadGuideText}
-        onJoin={handleJoinMeeting}
-        onCancelJoin={handleCancelJoinMeeting}
-        onAttend={() => handleAttendMeeting(detail.region)}
-        onShare={handleShareMeeting}
-        onEdit={handleEditMeeting}
-        onDelete={handleDeleteMeeting}
-        onToggleFavorite={() =>
-          handleToggleFavorite(viewModel.data.isFavorited)
-        }
-      />
-    </>
+    <MeetingDetailView
+      data={viewModel.data}
+      participantAvatars={viewModel.participantAvatars}
+      isFavoritePending={favoriteMutation.isPending}
+      isJoinPending={
+        joinMutation.isPending ||
+        cancelJoinMutation.isPending ||
+        attendMutation.isPending
+      }
+      isAuthLoading={isAuthLoading}
+      actionState={viewModel.actionState}
+      actionLabel={viewModel.actionLabel}
+      isActionDisabled={viewModel.isActionDisabled}
+      shouldShowShareButton={viewModel.shouldShowShareButton}
+      shouldShowHostMenu={viewModel.shouldShowHostMenu}
+      shouldShowParticipantMenu={viewModel.shouldShowParticipantMenu}
+      canViewLink={viewModel.canViewLink}
+      canWriteThread={viewModel.canWriteThread}
+      linkGuideText={viewModel.linkGuideText}
+      threadGuideText={viewModel.threadGuideText}
+      onJoin={handleJoinMeeting}
+      onCancelJoin={handleCancelJoinMeeting}
+      onAttend={() => handleAttendMeeting(detail.region)}
+      onShare={handleShareMeeting}
+      onEdit={handleEditMeeting}
+      onDelete={handleDeleteMeeting}
+      onToggleFavorite={() => handleToggleFavorite(viewModel.data.isFavorited)}
+    />
   );
 }

--- a/src/app/meetings/[id]/components/MeetingDetailView.tsx
+++ b/src/app/meetings/[id]/components/MeetingDetailView.tsx
@@ -13,10 +13,12 @@ export function MeetingDetailView({
   isFavoritePending,
   isJoinPending,
   isAuthLoading,
+  actionState,
   actionLabel,
   isActionDisabled,
+  shouldShowShareButton,
   shouldShowHostMenu,
-  shouldShowClosedGuide,
+  shouldShowParticipantMenu,
   canViewLink,
   canWriteThread,
   linkGuideText,
@@ -37,10 +39,12 @@ export function MeetingDetailView({
         isFavoritePending={isFavoritePending}
         isJoinPending={isJoinPending}
         isAuthLoading={isAuthLoading}
+        actionState={actionState}
         actionLabel={actionLabel}
         isActionDisabled={isActionDisabled}
+        shouldShowShareButton={shouldShowShareButton}
         shouldShowHostMenu={shouldShowHostMenu}
-        shouldShowClosedGuide={shouldShowClosedGuide}
+        shouldShowParticipantMenu={shouldShowParticipantMenu}
         onJoin={onJoin}
         onCancelJoin={onCancelJoin}
         onAttend={onAttend}

--- a/src/app/meetings/[id]/components/MeetingHeaderSection.tsx
+++ b/src/app/meetings/[id]/components/MeetingHeaderSection.tsx
@@ -2,13 +2,10 @@
 
 import Image from "next/image";
 import { useState } from "react";
-import { useRouter } from "next/navigation";
-
 import crownLgIcon from "@/assets/icon/crown/crown-lg.svg";
 import meatballsLgIcon from "@/assets/icon/meatballs/meatballs-lg.svg";
 import profileFemaleSm from "@/assets/img/profile/female1-sm.jpg";
 import { EditMeetingModal } from "@/app/meetings/_components/modal/EditMeetingModal";
-
 import { BtnCommon } from "@/components/ui/BtnCommon";
 import {
   DropdownMenu,
@@ -16,23 +13,15 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/DropdownCommon";
-import ModalBase from "@/components/ui/ModalBase";
-import {
-  Progress,
-  ProgressLabel,
-  ProgressValue,
-} from "@/components/ui/ProgressCommon";
-import { TagCommon } from "@/components/ui/TagCommon";
-import { MeetingMember, MeetingHeaderSectionProps } from "@/types";
-import { useLoginModalStore } from "@/store/useLoginModalStore";
 import { ConfirmDeleteModal } from "@/components/ui/ConfirmDeleteModal";
-import { BellOff, Calendar, Clock, Users2 } from "lucide-react";
 import { HeartIcon } from "@/components/icon/HeartIcon";
 import FallbackImage from "@/components/img/FallbackImage";
+import { useLoginModalStore } from "@/store/useLoginModalStore";
+import { Calendar, Clock, Users2 } from "lucide-react";
+import { MeetingHeaderSectionProps, MeetingMember } from "@/types";
 
 const formatMonthDay = (value: string) => {
   const date = new Date(value);
-
   return `${date.getMonth() + 1}월 ${date.getDate()}일`;
 };
 
@@ -53,18 +42,18 @@ const hasUsableProfileImage = (
   !value?.includes("example.com") &&
   !value?.startsWith("blob:");
 
-// ... (formatMonthDay, formatHourMinute, hasUsableProfileImage 함수 유지)
-
 export function MeetingHeaderSection({
   data,
   participantAvatars,
   isFavoritePending,
   isJoinPending,
   isAuthLoading,
+  actionState,
   actionLabel,
   isActionDisabled,
+  shouldShowShareButton,
   shouldShowHostMenu,
-  shouldShowClosedGuide,
+  shouldShowParticipantMenu,
   onJoin,
   onCancelJoin,
   onAttend,
@@ -73,10 +62,8 @@ export function MeetingHeaderSection({
   onDelete,
   onToggleFavorite,
 }: MeetingHeaderSectionProps) {
-  const router = useRouter();
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
-  const [isLoginConfirmOpen, setIsLoginConfirmOpen] = useState(false);
 
   const loginGuardAction = useLoginModalStore((s) => s.loginGuardAction);
 
@@ -91,25 +78,21 @@ export function MeetingHeaderSection({
   );
 
   const handleActionClick = async () => {
-    if (isAuthLoading) return;
-    if (!data.isLoggedIn) {
-      setIsLoginConfirmOpen(true);
-      return;
+    if (isAuthLoading || isJoinPending || isActionDisabled) return;
+
+    switch (actionState) {
+      case "guest_join":
+        return;
+      case "joinable":
+        await onJoin();
+        return;
+      case "attendance_ready":
+        await onAttend();
+        return;
+      case "attendance_checking":
+      case "attendance_done":
+        return;
     }
-    if (isJoinPending || isActionDisabled) return;
-    if (actionLabel === "출석하기") {
-      await onAttend();
-      return;
-    }
-    if (data.isHost) {
-      await onShare();
-      return;
-    }
-    if (data.isJoined) {
-      await onCancelJoin();
-      return;
-    }
-    await onJoin();
   };
 
   const handleFavoriteClick = () => {
@@ -143,7 +126,7 @@ export function MeetingHeaderSection({
       <section className="flex flex-col gap-6 md:flex-row md:items-stretch xl:gap-10">
         <div className="relative h-[240px] w-full shrink-0 overflow-hidden rounded-[32px] bg-slate-50 shadow-sm md:h-auto md:w-[320px] xl:w-[540px]">
           <FallbackImage
-            src={data.image ?? ''}
+            src={data.image ?? ""}
             alt={data.name}
             fill
             className="object-cover transition-transform duration-700 hover:scale-105"
@@ -171,15 +154,12 @@ export function MeetingHeaderSection({
                   )}
                 </div>
 
-                {/* 💡 2. 일시 & 메타 정보: 제목 바로 아래에 밀도 있게 배치 */}
                 <div className="mt-4 flex flex-wrap items-center gap-2">
-                  {/* 날짜 태그 */}
                   <div className="bg-main-purple/10 text-main-purple flex items-center gap-1.5 rounded-full px-3 py-1 text-[11px] font-black tracking-tight shadow-sm">
                     <Calendar size={12} strokeWidth={3} />
                     <span>{formatMonthDay(data.dateTime)}</span>
                   </div>
 
-                  {/* 시간 태그 */}
                   <div className="flex items-center gap-1.5 rounded-full border border-slate-200 bg-white px-3 py-1 text-[11px] font-black tracking-tight text-slate-600 shadow-sm">
                     <Clock
                       size={12}
@@ -191,40 +171,68 @@ export function MeetingHeaderSection({
                 </div>
               </div>
 
-              {/* 💡 호스트 전용 메뉴 (버튼 크기 살짝 조정) */}
-              {shouldShowHostMenu && (
-                <DropdownMenu>
-                  <DropdownMenuTrigger
-                    render={
-                      <button
-                        type="button"
-                        className="group rounded-full p-2 transition hover:bg-slate-50"
-                      >
-                        <Image
-                          src={meatballsLgIcon}
-                          alt="Menu"
-                          width={28}
-                          height={28}
-                          className="opacity-40 group-hover:opacity-100"
-                        />
-                      </button>
-                    }
-                  />
-                  <DropdownMenuContent align="end">
-                    <DropdownMenuItem onClick={() => setIsEditModalOpen(true)}>
-                      수정하기
-                    </DropdownMenuItem>
-                    <DropdownMenuItem
-                      onClick={() => setIsDeleteModalOpen(true)}
-                      className="font-bold text-red-500"
-                    >
-                      삭제하기
-                    </DropdownMenuItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              )}
+              <div className="flex shrink-0 items-center gap-2">
+                {shouldShowShareButton && (
+                  <BtnCommon
+                    type="button"
+                    size="sm"
+                    variant="teritary"
+                    onClick={() => loginGuardAction(onShare)}
+                    className="!rounded-2xl"
+                  >
+                    공유
+                  </BtnCommon>
+                )}
+
+                {(shouldShowHostMenu || shouldShowParticipantMenu) && (
+                  <DropdownMenu>
+                    <DropdownMenuTrigger
+                      render={
+                        <button
+                          type="button"
+                          className="group rounded-full p-2 transition hover:bg-slate-50"
+                        >
+                          <Image
+                            src={meatballsLgIcon}
+                            alt="Menu"
+                            width={28}
+                            height={28}
+                            className="flex size-10 shrink-0 items-center justify-center rounded-full border border-slate-200 bg-white"
+                          />
+                        </button>
+                      }
+                    />
+                    <DropdownMenuContent align="end">
+                      {shouldShowHostMenu ? (
+                        <>
+                          <DropdownMenuItem
+                            onClick={() => setIsEditModalOpen(true)}
+                          >
+                            모임 수정하기
+                          </DropdownMenuItem>
+                          <DropdownMenuItem
+                            onClick={() => setIsDeleteModalOpen(true)}
+                            className="font-bold text-red-500"
+                          >
+                            모임 삭제하기
+                          </DropdownMenuItem>
+                        </>
+                      ) : null}
+
+                      {shouldShowParticipantMenu ? (
+                        <DropdownMenuItem
+                          onClick={onCancelJoin}
+                          className="font-bold text-red-500"
+                        >
+                          모임 탈퇴하기
+                        </DropdownMenuItem>
+                      ) : null}
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                )}
+              </div>
             </div>
-            {/* 💡 세련된 참여 현황 통합 박스 */}
+
             <div className="group relative rounded-[28px] bg-slate-50 p-4 transition-all">
               <div className="mb-5 flex items-center justify-between">
                 <div className="flex items-center gap-3">
@@ -253,7 +261,6 @@ export function MeetingHeaderSection({
                 </div>
               </div>
 
-              {/* 에메랄드 글로우 프로그레스 바 */}
               <div className="relative h-2.5 w-full overflow-hidden rounded-full bg-slate-200">
                 <div
                   className="h-full rounded-full bg-purple-400 shadow-[0_0_15px_rgba(52,211,153,0.5)] transition-all duration-1000 ease-out"
@@ -263,15 +270,7 @@ export function MeetingHeaderSection({
             </div>
           </div>
 
-          {/* 하단 액션 버튼 영역 */}
           <div className="mt-5 flex items-center gap-4 sm:mt-10">
-            <HeartIcon
-              liked={data.isFavorited}
-              onClick={() => loginGuardAction(handleFavoriteClick)}
-              size={28}
-              disabled={isFavoritePending}
-            />
-
             <BtnCommon
               type="button"
               size="md"
@@ -283,18 +282,16 @@ export function MeetingHeaderSection({
                 {isJoinPending ? "PROCESSING..." : actionLabel}
               </span>
             </BtnCommon>
+            <HeartIcon
+              liked={data.isFavorited}
+              onClick={() => loginGuardAction(handleFavoriteClick)}
+              size={28}
+              disabled={isFavoritePending}
+            />
           </div>
-
-          {shouldShowClosedGuide && (
-            <div className="mt-6 flex items-center justify-center gap-2 rounded-2xl bg-red-50/50 py-3 text-[11px] font-bold text-red-400">
-              <BellOff size={14} />
-              모집 마감되어 참여할 수 없습니다.
-            </div>
-          )}
         </div>
       </section>
 
-      {/* 모달 로직들 유지 */}
       <EditMeetingModal
         isOpen={isEditModalOpen}
         onOpenChange={setIsEditModalOpen}
@@ -312,41 +309,6 @@ export function MeetingHeaderSection({
           setIsDeleteModalOpen(false);
         }}
       />
-
-      <ModalBase
-        isOpen={isLoginConfirmOpen}
-        onOpenChange={setIsLoginConfirmOpen}
-        contentClassName="w-full sm:w-[400px] rounded-[32px] p-8 text-center"
-      >
-        <div className="flex flex-col items-center py-4">
-          <p className="text-2xl font-black tracking-tighter text-slate-950">
-            로그인이 필요합니다
-          </p>
-          <p className="mt-2 text-sm font-medium text-slate-400">
-            서비스를 이용하시려면 먼저 로그인해 주세요.
-          </p>
-          <div className="mt-8 flex w-full flex-col gap-3">
-            <BtnCommon
-              size="md"
-              className="!rounded-2xl bg-slate-950 text-white"
-              onClick={() => {
-                setIsLoginConfirmOpen(false);
-                router.push("/login");
-              }}
-            >
-              로그인 하기
-            </BtnCommon>
-            <BtnCommon
-              variant="teritary"
-              size="md"
-              className="!rounded-2xl"
-              onClick={() => setIsLoginConfirmOpen(false)}
-            >
-              취소
-            </BtnCommon>
-          </div>
-        </div>
-      </ModalBase>
     </>
   );
 }

--- a/src/hooks/queries/useMeetingDetail.ts
+++ b/src/hooks/queries/useMeetingDetail.ts
@@ -30,12 +30,9 @@ import {
   MeetingActionErrorResponse,
   MeetingDetailApiData,
   MeetingDetailData,
-  Post,
 } from "@/types";
 import {
   deleteFavorites,
-  likePost,
-  unlikePost,
   updateFavorites,
 } from "@/api/client";
 import { useOptimisticMutation } from "@/hooks/useOptimisticUpdate";
@@ -230,10 +227,13 @@ export function useMeetingDetailMutations({
     },
   });
 
+  const isCheckingAttendance = attendMutation.isPending;
+
   return {
     user,
     isAuthLoading,
     hasAttended,
+    isCheckingAttendance,
     joinMutation,
     cancelJoinMutation,
     favoriteMutation,

--- a/src/types/meeting.ts
+++ b/src/types/meeting.ts
@@ -215,10 +215,12 @@ export interface MeetingHeaderSectionProps {
   isFavoritePending: boolean;
   isJoinPending: boolean;
   isAuthLoading: boolean;
+  actionState: MeetingActionState;
   actionLabel: string;
   isActionDisabled: boolean;
+  shouldShowShareButton: boolean;
   shouldShowHostMenu: boolean;
-  shouldShowClosedGuide: boolean;
+  shouldShowParticipantMenu: boolean;
   onJoin: () => Promise<void> | void;
   onCancelJoin: () => Promise<void> | void;
   onAttend: () => Promise<void> | void;
@@ -234,6 +236,13 @@ export interface MeetingDetailViewProps extends MeetingHeaderSectionProps {
   linkGuideText: string;
   threadGuideText: string;
 }
+
+export type MeetingActionState =
+  | "guest_join"
+  | "joinable"
+  | "attendance_checking"
+  | "attendance_ready"
+  | "attendance_done";
 
 export interface MeetingDetailContentProps {
   meetingId: number;


### PR DESCRIPTION
## 🔗 Issue Number

- close: #361 

## 📝 Change Log

### 🤖 Generated by PR Agent at 87afdc22e12e990eac7b0901801d1adb7ac66e98

    - 모임 상세 페이지 상단 액션 영역을 상태 기반 UI로 개편했습니다.
    - `MeetingActionState` 타입을 도입하여 5가지 상태(guest_join, joinable, attendance_checking, attendance_ready, attendance_done)로 관리했습니다.
    - 호스트 메뉴와 참여자 메뉴를 분리하고 공유 버튼을 별도로 노출했습니다.
    - 액션 버튼 로직을 상태 기반 switch 문으로 단순화하고 불필요한 함수들을 제거했습니다.
  
  ### ⚡ Tech Stack & Patterns
  - [x] Architecture: Function Declaration & Named Export 준수
  - [x] Naming: camelCase, actionState, isCheckingAttendance 형식 준수
  - [x] Styling: Semantic Tag 사용
  - [x] URL: RESTful 구조 및 Lowercase 경로 확인
  


## 💬 Reviewer's Guide

> 코드 리뷰 시 중점적으로 봐주었으면 하는 부분이나 논의가 필요한 지점을 적어주세요.

-