### PR TITLE
[FEAT] 마이페이지 데이터연결

### DIFF
--- a/src/api/server/index.ts
+++ b/src/api/server/index.ts
@@ -1,4 +1,5 @@
 export * from "./favorites";
 export * from "./meetings";
 export * from "./posts";
+export * from "./stats";
 export * from "./users";

--- a/src/api/server/posts.ts
+++ b/src/api/server/posts.ts
@@ -2,8 +2,8 @@ import { serverAxios, serverFetch } from "@/lib/serverFetcher";
 import type {
   GetCommentsResponse,
   GetPostsResponse,
-  MyPostsPageResponse,
   Post,
+  VisiblePostsPageResponse,
 } from "@/types";
 import { filterThreadPosts } from "@/lib/postUtils";
 import { getVisibleMyPostsPage } from "@/lib/myVisiblePosts";
@@ -56,7 +56,7 @@ export async function getMyPostsServer(
     offset?: number;
     limit?: number;
   } = {},
-): Promise<MyPostsPageResponse> {
+): Promise<VisiblePostsPageResponse> {
   return getVisibleMyPostsPage(
     {
       offset: params.offset ?? 0,

--- a/src/api/server/stats.ts
+++ b/src/api/server/stats.ts
@@ -1,6 +1,9 @@
-import { getFavorites, getMyMeetings } from "./favorites";
+import { getMyMeetings } from "./favorites";
 import { getMyPostsServer } from "./posts";
-import { getUserMeetingsPageServer, getUserPostsPageServer } from "./users";
+import {
+  getUserMeetingsPageServer,
+  getUserPostsPageServer,
+} from "./users";
 
 export interface ProfileStats {
   postCount: number;
@@ -16,8 +19,7 @@ export async function getProfileStats({
   userId: number;
 }): Promise<ProfileStats> {
   if (isOwnProfile) {
-    const [favorites, meetings, posts] = await Promise.all([
-      getFavorites({ offset: 0, limit: 1 }),
+    const [meetings, posts] = await Promise.all([
       getMyMeetings({ offset: 0, limit: 1 }),
       getMyPostsServer({ offset: 0, limit: 1 }),
     ]);
@@ -25,7 +27,7 @@ export async function getProfileStats({
     return {
       postCount: posts.totalCount,
       meetingCount: meetings.totalCount,
-      favoriteCount: favorites.totalCount,
+      favoriteCount: posts.totalLikeCount,
     };
   }
 
@@ -37,6 +39,6 @@ export async function getProfileStats({
   return {
     postCount: posts.totalCount,
     meetingCount: meetings.totalCount,
-    favoriteCount: 0,
+    favoriteCount: posts.totalLikeCount,
   };
 }

--- a/src/api/server/stats.ts
+++ b/src/api/server/stats.ts
@@ -1,0 +1,42 @@
+import { getFavorites, getMyMeetings } from "./favorites";
+import { getMyPostsServer } from "./posts";
+import { getUserMeetingsPageServer, getUserPostsPageServer } from "./users";
+
+export interface ProfileStats {
+  postCount: number;
+  meetingCount: number;
+  favoriteCount: number;
+}
+
+export async function getProfileStats({
+  isOwnProfile,
+  userId,
+}: {
+  isOwnProfile: boolean;
+  userId: number;
+}): Promise<ProfileStats> {
+  if (isOwnProfile) {
+    const [favorites, meetings, posts] = await Promise.all([
+      getFavorites({ offset: 0, limit: 1 }),
+      getMyMeetings({ offset: 0, limit: 1 }),
+      getMyPostsServer({ offset: 0, limit: 1 }),
+    ]);
+
+    return {
+      postCount: posts.totalCount,
+      meetingCount: meetings.totalCount,
+      favoriteCount: favorites.totalCount,
+    };
+  }
+
+  const [meetings, posts] = await Promise.all([
+    getUserMeetingsPageServer({ userId, offset: 0, limit: 1 }),
+    getUserPostsPageServer({ userId, offset: 0, limit: 1 }),
+  ]);
+
+  return {
+    postCount: posts.totalCount,
+    meetingCount: meetings.totalCount,
+    favoriteCount: 0,
+  };
+}

--- a/src/api/server/users.ts
+++ b/src/api/server/users.ts
@@ -1,15 +1,14 @@
 import { serverAxios } from "@/lib/serverFetcher";
-import { filterThreadPosts } from "@/lib/postUtils";
 import { getVisibleCursorPage } from "@/lib/visibleCursorPage";
 import type {
   GetPostsResponse,
   MeetingResponse,
   GetMeetingsResponse,
   MyMeetingsPageResponse,
-  MyPostsPageResponse,
-  Post,
   User,
+  VisiblePostsPageResponse,
 } from "@/types";
+import { getVisiblePostsPage } from "@/lib/myVisiblePosts";
 
 export async function getPublicUserProfile({ userId }: { userId: number }) {
   const response = await serverAxios.get<User>(`/users/${userId}`);
@@ -55,23 +54,24 @@ export async function getUserPostsPageServer({
   userId: number;
   offset?: number;
   limit?: number;
-}): Promise<MyPostsPageResponse> {
-  return getVisibleCursorPage<Post>({
-    offset,
-    limit,
-    fetchPage: async ({ cursor, size }) => {
+}): Promise<VisiblePostsPageResponse> {
+  return getVisiblePostsPage(
+    { offset, limit },
+    async ({ offset: pageOffset, limit: pageLimit }) => {
       const { data } = await serverAxios.get<GetPostsResponse>("/posts", {
         params: {
           keyword: "",
           sortBy: "createdAt",
           sortOrder: "desc",
-          size,
-          ...(cursor ? { cursor } : {}),
+          offset: pageOffset,
+          limit: pageLimit,
         },
       });
 
-      return filterThreadPosts(data);
+      return data;
     },
-    filter: (post) => post.author.id === userId,
-  });
+    {
+      filter: (post) => post.author.id === userId,
+    },
+  );
 }

--- a/src/app/api/users/[id]/posts-visible/route.ts
+++ b/src/app/api/users/[id]/posts-visible/route.ts
@@ -1,8 +1,7 @@
 import { NextResponse } from "next/server";
 import { serverAxios } from "@/lib/serverFetcher";
-import { getVisibleCursorPage } from "@/lib/visibleCursorPage";
-import { filterThreadPosts } from "@/lib/postUtils";
-import type { GetPostsResponse, MyPostsPageResponse, Post } from "@/types";
+import { getVisiblePostsPage } from "@/lib/myVisiblePosts";
+import type { GetPostsResponse, VisiblePostsPageResponse } from "@/types";
 
 interface RouteParams {
   params: Promise<{ id: string }>;
@@ -23,26 +22,30 @@ export async function GET(request: Request, { params }: RouteParams) {
   }
 
   try {
-    const data = await getVisibleCursorPage<Post>({
-      offset: safeOffset,
-      limit: safeLimit,
-      fetchPage: async ({ cursor, size }) => {
+    const data = await getVisiblePostsPage(
+      {
+        offset: safeOffset,
+        limit: safeLimit,
+      },
+      async ({ offset: pageOffset, limit: pageLimit }) => {
         const response = await serverAxios.get<GetPostsResponse>("/posts", {
           params: {
             keyword: "",
             sortBy: "createdAt",
             sortOrder: "desc",
-            size,
-            ...(cursor ? { cursor } : {}),
+            offset: pageOffset,
+            limit: pageLimit,
           },
         });
 
-        return filterThreadPosts(response.data);
+        return response.data;
       },
-      filter: (post) => post.author.id === userId,
-    });
+      {
+        filter: (post) => post.author.id === userId,
+      },
+    );
 
-    return NextResponse.json<MyPostsPageResponse>(data);
+    return NextResponse.json<VisiblePostsPageResponse>(data);
   } catch (error) {
     console.error("[Visible User Posts BFF Error]", error);
     return NextResponse.json(

--- a/src/app/api/users/me/posts-visible/route.ts
+++ b/src/app/api/users/me/posts-visible/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { serverAxios } from "@/lib/serverFetcher";
 import { getVisibleMyPostsPage } from "@/lib/myVisiblePosts";
-import type { MyPostsPageResponse } from "@/types";
+import type { GetPostsResponse, VisiblePostsPageResponse } from "@/types";
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
@@ -18,7 +18,7 @@ export async function GET(request: Request) {
         limit: safeLimit,
       },
       async ({ offset: pageOffset, limit: pageLimit }) => {
-        const response = await serverAxios.get<MyPostsPageResponse>(
+        const response = await serverAxios.get<GetPostsResponse>(
           "/users/me/posts",
           {
             params: {
@@ -34,7 +34,7 @@ export async function GET(request: Request) {
       },
     );
 
-    return NextResponse.json(data);
+    return NextResponse.json<VisiblePostsPageResponse>(data);
   } catch (error) {
     console.error("[Visible My Posts BFF Error]", error);
     return NextResponse.json(

--- a/src/app/users/[id]/_components/StatGrid.tsx
+++ b/src/app/users/[id]/_components/StatGrid.tsx
@@ -1,6 +1,7 @@
 import { cn } from "@/lib/utils";
 
 interface StatGridProps {
+  isOwnProfile: boolean;
   postCount: number;
   meetingCount: number;
   favoriteCount: number;
@@ -25,10 +26,7 @@ export default function StatGrid({
             {meetingCount}개
           </dd>
         </div>
-        <div
-          className="text-xl sm:text-2xl"
-          aria-hidden="true"
-        >
+        <div className="text-xl sm:text-2xl" aria-hidden="true">
           🏗️
         </div>
       </div>

--- a/src/app/users/[id]/_components/StatGrid.tsx
+++ b/src/app/users/[id]/_components/StatGrid.tsx
@@ -1,7 +1,6 @@
 import { cn } from "@/lib/utils";
 
 interface StatGridProps {
-  isOwnProfile: boolean;
   postCount: number;
   meetingCount: number;
   favoriteCount: number;

--- a/src/app/users/[id]/page.tsx
+++ b/src/app/users/[id]/page.tsx
@@ -17,6 +17,7 @@ import {
   getFavorites,
   getMyMeetings,
   getMyPostsServer,
+  getProfileStats,
   getPublicUserProfile,
   getUserMeetingsPageServer,
   getUserPostsPageServer,
@@ -58,6 +59,10 @@ export default async function Page({
         userId: profileUserId,
       })
     : initialUser;
+  const stats = await getProfileStats({
+    isOwnProfile,
+    userId: profileUserId,
+  });
 
   const tabs = isOwnProfile
     ? [
@@ -99,9 +104,9 @@ export default async function Page({
           {/* 2. 게이미피케이션 스탯 그리드 구역 (옆으로 슬라이드) */}
           <div className="min-w-[90%] snap-center lg:min-w-full">
             <StatGrid
-              postCount={10}
-              meetingCount={2}
-              favoriteCount={5}
+              postCount={stats.postCount}
+              meetingCount={stats.meetingCount}
+              favoriteCount={stats.favoriteCount}
               // insight="오늘도 즐거운 코딩 되세요! 🚀"
             />
           </div>

--- a/src/lib/myVisiblePosts.ts
+++ b/src/lib/myVisiblePosts.ts
@@ -1,4 +1,4 @@
-import type { GetPostsResponse, MyPostsPageResponse, Post } from "@/types";
+import type { GetPostsResponse, Post, VisiblePostsPageResponse } from "@/types";
 import { filterThreadPosts } from "@/lib/postUtils";
 
 interface FetchMyPostsPageParams {
@@ -18,14 +18,18 @@ type FetchMyPostsPage = (
 
 const SCAN_PAGE_SIZE = 100;
 
-export async function getVisibleMyPostsPage(
+export async function getVisiblePostsPage(
   params: FetchMyPostsPageParams,
   fetchPage: FetchMyPostsPage,
-): Promise<MyPostsPageResponse> {
+  options: {
+    filter?: (post: Post) => boolean;
+  } = {},
+): Promise<VisiblePostsPageResponse> {
   const targetOffset = params.offset;
   const targetLimit = params.limit;
   const visiblePosts: Post[] = [];
   let visibleTotalCount = 0;
+  let visibleTotalLikeCount = 0;
   let sourceOffset = 0;
   let hasMoreSource = true;
   let expectedSourceTotal = Number.POSITIVE_INFINITY;
@@ -37,18 +41,24 @@ export async function getVisibleMyPostsPage(
     });
 
     const filtered = filterThreadPosts(response);
-    visibleTotalCount += filtered.data.length;
+    const scopedPosts = options.filter
+      ? filtered.data.filter(options.filter)
+      : filtered.data;
+
+    visibleTotalCount += scopedPosts.length;
+    visibleTotalLikeCount += scopedPosts.reduce(
+      (sum, post) => sum + post.likeCount,
+      0,
+    );
 
     if (visibleTotalCount > targetOffset && visiblePosts.length < targetLimit) {
       const startIndex = Math.max(
         0,
-        targetOffset - (visibleTotalCount - filtered.data.length),
+        targetOffset - (visibleTotalCount - scopedPosts.length),
       );
       const remaining = targetLimit - visiblePosts.length;
 
-      visiblePosts.push(
-        ...filtered.data.slice(startIndex, startIndex + remaining),
-      );
+      visiblePosts.push(...scopedPosts.slice(startIndex, startIndex + remaining));
     }
 
     const sourcePageSize =
@@ -67,9 +77,17 @@ export async function getVisibleMyPostsPage(
   return {
     data: visiblePosts,
     totalCount: visibleTotalCount,
+    totalLikeCount: visibleTotalLikeCount,
     currentOffset: targetOffset,
     limit: targetLimit,
     hasMore: currentPageEnd < visibleTotalCount,
     nextCursor: null,
   };
+}
+
+export async function getVisibleMyPostsPage(
+  params: FetchMyPostsPageParams,
+  fetchPage: FetchMyPostsPage,
+): Promise<VisiblePostsPageResponse> {
+  return getVisiblePostsPage(params, fetchPage);
 }

--- a/src/types/post.ts
+++ b/src/types/post.ts
@@ -34,6 +34,10 @@ export interface GetPostsParams {
 
 export type GetPostsResponse = CursorResponse<Post>;
 export type MyPostsPageResponse = OffsetResponse<Post>;
+// 이건 BFF가 계산한 추가 정보가 붙은 응답
+export interface VisiblePostsPageResponse extends MyPostsPageResponse {
+  totalLikeCount: number;
+}
 
 export interface PostListProps {
   searchValue?: string;


### PR DESCRIPTION
## 🔗 Issue Number

- close: #426 

## 📝 Change Log
마이페이지 상단 스탯(StatGrid)의 데이터 일관성을 높이고, 백엔드 제약을 BFF 계층에서 해결한 작업입니다. 특히 '찜 수'로 대체되어 있던 좋아요 항목을 '게시글이 받은 총 좋아요 수'로 정상화했습니다.

1. 통계 데이터 기준 일관성 확보
기존: favoriteCount가 '찜한 모임 수'를 표시하여 게시글/모임 수와 데이터 성격이 맞지 않음.
변경: 게시글 목록 API를 활용해 실제 게시글들의 likeCount 합계를 산출하여 노출.

2. 효율적인 데이터 소스 이원화 (Internal Routing)
동일한 응답 규격(VisiblePostsPageResponse)을 반환하되, 상황에 맞는 최적의 경로를 타도록 설계했습니다.

내 마이페이지 (Own): /users/me/posts 전용 엔드포인트를 활용하여 불필요한 전체 스캔 방지 (성능 최적화).
타인 마이페이지 (User): 전용 API가 없으므로 전체 /posts를 스캔하되, BFF에서 필터링 및 통계 계산을 대행.

3. BFF 스캔 로직 고도화 (getVisiblePostsPage)
기존에 totalCount 산출을 위해 수행하던 데이터 순회(Scanning) 과정에 totalLikeCount 누적 로직을 통합.
추가적인 API 호출 없이 목록 조회 시점에 전체 좋아요 합계를 한 번에 계산하여 응답.


## 💬 Reviewer's Guide

> 코드 리뷰 시 중점적으로 봐주었으면 하는 부분이나 논의가 필요한 지점을 적어주세요.

-
