### PR TITLE
[REFACTOR]  출석하기 애니메이션/보상 UI 로직 연결

### DIFF
--- a/src/api/client/meetingDetail.ts
+++ b/src/api/client/meetingDetail.ts
@@ -114,10 +114,13 @@ export async function attendMeeting(region: string) {
     throw new Error("INVALID_ATTENDANCE_POST_ID");
   }
 
-  await createComment(
+  const attendScore = Math.floor(Math.random() * 5) + 1;
+
+  const comment = await createComment(
     postId,
-    `onlyScore_${region}_${Math.floor(Math.random() * 5) + 1}`,
+    `onlyScore_${region}_${attendScore}`,
   );
+  return { comment, attendScore };
 }
 
 export async function uploadMeetingImage(file: File) {

--- a/src/app/meetings/[id]/components/MeetingHeaderSection.tsx
+++ b/src/app/meetings/[id]/components/MeetingHeaderSection.tsx
@@ -196,15 +196,15 @@ export function MeetingHeaderSection({
       label: "출석하기",
       disabled: false,
       handler: () => {
-        handleAttendMeeting(detail.region);
-
-        const earnedPoint = Math.floor(Math.random() * 3) + 1;
-
-        setShowReward({
-          show: true,
-          point: earnedPoint,
+        handleAttendMeeting(detail.region, {
+          onSuccess: (result) => {
+            setShowReward({
+              show: true,
+              point: result.attendScore,
+            });
+            setIsAnimating(true);
+          },
         });
-        setIsAnimating(true);
       },
     };
   })();
@@ -401,11 +401,11 @@ export function MeetingHeaderSection({
               type="button"
               size="md"
               disabled={action.disabled || isActionPending || isAuthLoading}
-              onClick={() => loginGuardAction(action.handler)}
+              onClick={() => loginGuardAction(() => void action.handler())}
               className="bg-main-purple hover:bg-main-purple/80 h-16 flex-1 !rounded-[24px] font-bold tracking-[0.1em] text-white shadow-[0_15px_30px_rgba(38,6,86,0.2)] transition-all active:scale-[0.98]"
             >
               <span className="tracking-widest sm:text-sm">
-                {isActionPending ? "PROCESSING..." : action.label}
+                {isActionPending ? "진행중..." : action.label}
               </span>
             </BtnCommon>
             <HeartIcon

--- a/src/hooks/queries/useMeetingDetail.ts
+++ b/src/hooks/queries/useMeetingDetail.ts
@@ -213,6 +213,7 @@ export function useMeetingAttendMutation(meetingId: number) {
     mutationFn: attendMeeting,
     onSuccess: () => {
       setHasAttended(true);
+
       ToastCommon({ message: "출석이 완료되었습니다.", size: "sm" });
     },
     onError: () => {
@@ -220,11 +221,22 @@ export function useMeetingAttendMutation(meetingId: number) {
     },
   });
 
+  // 공통 성공/실패 처리는 mutation에서 담당하고,
+  //  UI(보상/애니메이션)만 호출 시 onSuccess로 분리
   return {
     hasAttended,
     isCheckingAttendance: attendMutation.isPending,
-    handleAttendMeeting: (region: string) => {
-      attendMutation.mutate(region);
+    handleAttendMeeting: (
+      region: string,
+      options?: {
+        onSuccess?: (result: Awaited<ReturnType<typeof attendMeeting>>) => void;
+      },
+    ) => {
+      attendMutation.mutate(region, {
+        onSuccess: (result) => {
+          options?.onSuccess?.(result);
+        },
+      });
     },
   };
 }


### PR DESCRIPTION
## 🔗 Issue Number

- close: #442 

## 📝 Change Log

- 출석 성공 시점에만 보상 UI와 체크 애니메이션이 실행되도록 흐름 정리
- 출석 요청 결과로 반환된 점수를 기준으로 보상 UI가 동작하도록 연결
- `useMutation`의 공통 성공/실패 처리는 hook 내부에서 유지하고, 화면 전용 성공 후처리는 `handleAttendMeeting(..., { onSuccess })`로 분리


## 💬 Reviewer's Guide

> 코드 리뷰 시 중점적으로 봐주었으면 하는 부분이나 논의가 필요한 지점을 적어주세요.

-
