### PR TITLE
[FIX] suspense 도입 및 early fetch

### DIFF
--- a/src/api/server/stats.ts
+++ b/src/api/server/stats.ts
@@ -12,11 +12,10 @@ export interface ParticipantStats {
   etc: number;
 }
 
-export interface ProfileStats {
+export interface BasicProfileStats {
   postCount: number;
   meetingCount: number;
   favoriteCount: number;
-  participantStats: ParticipantStats;
 }
 
 const MEETING_SCAN_SIZE = 100;
@@ -122,38 +121,48 @@ async function getUserMeetingParticipantStats(
   return stats;
 }
 
-export async function getProfileStats({
+export async function getBasicProfileStats({
   isOwnProfile,
   userId,
 }: {
   isOwnProfile: boolean;
   userId: number;
-}): Promise<ProfileStats> {
+}): Promise<BasicProfileStats> {
   if (isOwnProfile) {
-    const [meetings, posts, participantStats] = await Promise.all([
+    const [meetings, posts] = await Promise.all([
       getMyMeetings({ offset: 0, limit: 1 }),
       getMyPostsServer({ offset: 0, limit: 1 }),
-      getOwnMeetingParticipantStats(),
     ]);
 
     return {
       postCount: posts.totalCount,
       meetingCount: meetings.totalCount,
       favoriteCount: posts.totalLikeCount,
-      participantStats,
     };
   }
 
-  const [meetings, posts, participantStats] = await Promise.all([
+  const [meetings, posts] = await Promise.all([
     getUserMeetingsPageServer({ userId, offset: 0, limit: 1 }),
     getUserPostsPageServer({ userId, offset: 0, limit: 1 }),
-    getUserMeetingParticipantStats(userId),
   ]);
 
   return {
     postCount: posts.totalCount,
     meetingCount: meetings.totalCount,
     favoriteCount: posts.totalLikeCount,
-    participantStats,
   };
+}
+
+export async function getDetailedParticipantStats({
+  isOwnProfile,
+  userId,
+}: {
+  isOwnProfile: boolean;
+  userId: number;
+}): Promise<ParticipantStats> {
+  if (isOwnProfile) {
+    return getOwnMeetingParticipantStats();
+  }
+
+  return getUserMeetingParticipantStats(userId);
 }

--- a/src/app/users/[id]/_components/StatGridContainer.tsx
+++ b/src/app/users/[id]/_components/StatGridContainer.tsx
@@ -1,0 +1,24 @@
+import type { BasicProfileStats, ParticipantStats } from "@/api/server";
+import StatGrid from "./StatGrid";
+
+export default async function StatGridContainer({
+  basicStatsPromise,
+  participantStatsPromise,
+}: {
+  basicStatsPromise: Promise<BasicProfileStats>;
+  participantStatsPromise: Promise<ParticipantStats>;
+}) {
+  const [basicStats, participantStats] = await Promise.all([
+    basicStatsPromise,
+    participantStatsPromise,
+  ]);
+
+  return (
+    <StatGrid
+      postCount={basicStats.postCount}
+      meetingCount={basicStats.meetingCount}
+      favoriteCount={basicStats.favoriteCount}
+      participantStats={participantStats}
+    />
+  );
+}

--- a/src/app/users/[id]/page.tsx
+++ b/src/app/users/[id]/page.tsx
@@ -11,12 +11,14 @@ import FavoriteList from "@/app/users/[id]/_components/FavoriteList";
 import type { FavoritesPageResponse } from "@/types";
 import {
   getFavorites,
-  getProfileStats,
+  getBasicProfileStats,
+  getDetailedParticipantStats,
   getPublicUserProfile,
 } from "@/api/server";
 import { UserTabSkeleton } from "@/components/skeleton/UserTabSkeleton";
 import { QUERY_KEYS } from "@/constans/queryKey";
 import StatGrid from "./_components/StatGrid";
+import StatGridContainer from "./_components/StatGridContainer";
 import GradeCard from "./_components/GridCard";
 
 const FAVORITES_PAGE_SIZE = 10;
@@ -44,15 +46,21 @@ export default async function Page({
   const initialUser = raw ? JSON.parse(raw) : null;
   const isOwnProfile = initialUser?.id === Number(id);
   const profileUserId = Number(id);
+
+  const basicStatsPromise = getBasicProfileStats({
+    isOwnProfile,
+    userId: profileUserId,
+  });
+  const participantStatsPromise = getDetailedParticipantStats({
+    isOwnProfile,
+    userId: profileUserId,
+  });
+
   const profileUser = Number.isFinite(Number(id))
     ? await getPublicUserProfile({
         userId: profileUserId,
       })
     : initialUser;
-  const stats = await getProfileStats({
-    isOwnProfile,
-    userId: profileUserId,
-  });
 
   const tabs = isOwnProfile
     ? [
@@ -93,13 +101,27 @@ export default async function Page({
 
           {/* 2. 게이미피케이션 스탯 그리드 구역 (옆으로 슬라이드) */}
           <div className="min-w-[90%] snap-center lg:min-w-full">
-            <StatGrid
-              postCount={stats.postCount}
-              meetingCount={stats.meetingCount}
-              favoriteCount={stats.favoriteCount}
-              participantStats={stats.participantStats}
-              // insight="오늘도 즐거운 코딩 되세요! 🚀"
-            />
+            <Suspense
+              fallback={
+                <StatGrid
+                  postCount={0}
+                  meetingCount={0}
+                  favoriteCount={0}
+                  participantStats={{
+                    team: 0,
+                    study: 0,
+                    project: 0,
+                    jobPrep: 0,
+                    etc: 0,
+                  }}
+                />
+              }
+            >
+              <StatGridContainer
+                basicStatsPromise={basicStatsPromise}
+                participantStatsPromise={participantStatsPromise}
+              />
+            </Suspense>
           </div>
         </aside>
 


### PR DESCRIPTION
## 🔗 Issue Number

- close: #452 

## 📝 Change Log
early fetch + suspense
이전: src/app/users/[id]/page.tsx에서 await getProfileStats()로 페이지 전체가 대기
지금: stats Promise를 먼저 시작하고, Suspense 안 src/app/users/[id]/_components/StatGridContainer.tsx에서 기다려서 stat 영역만 대기(무거운 로직은 따로 처리)

## 💬 Reviewer's Guide

> 코드 리뷰 시 중점적으로 봐주었으면 하는 부분이나 논의가 필요한 지점을 적어주세요.

-
