### PR TITLE
[FIX] getpublicuserprofile await 제거

### DIFF
--- a/src/app/users/[id]/_components/ProfileSectionContainer.tsx
+++ b/src/app/users/[id]/_components/ProfileSectionContainer.tsx
@@ -1,0 +1,22 @@
+import ProfileSection from "@/app/users/[id]/_components/ProfileSection";
+
+type ProfileSectionUser = {
+  id: number;
+  teamId?: string;
+  name: string;
+  image: string | null;
+  email: string;
+  companyName: string;
+} | null;
+
+export default async function ProfileSectionContainer({
+  profileUserPromise,
+  canEdit,
+}: {
+  profileUserPromise: Promise<ProfileSectionUser>;
+  canEdit: boolean;
+}) {
+  const profileUser = await profileUserPromise;
+
+  return <ProfileSection initialUser={profileUser} canEdit={canEdit} />;
+}

--- a/src/app/users/[id]/page.tsx
+++ b/src/app/users/[id]/page.tsx
@@ -3,6 +3,7 @@ import { Metadata } from "next";
 import { Tab } from "@/components/ui/Tab";
 import { TabsContent } from "@/components/shadcnOrigin/tabs";
 import ProfileSection from "@/app/users/[id]/_components/ProfileSection";
+import ProfileSectionContainer from "@/app/users/[id]/_components/ProfileSectionContainer";
 import PrefetchBoundary from "@/components/boundary/PrefetchBoundary";
 import MyMeetingList from "@/app/users/[id]/_components/MyMeetingList";
 import MyPostList from "@/app/users/[id]/_components/MyPostList";
@@ -55,12 +56,11 @@ export default async function Page({
     isOwnProfile,
     userId: profileUserId,
   });
-
-  const profileUser = Number.isFinite(Number(id))
-    ? await getPublicUserProfile({
+  const profileUserPromise = Number.isFinite(profileUserId)
+    ? getPublicUserProfile({
         userId: profileUserId,
       })
-    : initialUser;
+    : Promise.resolve(initialUser);
 
   const tabs = isOwnProfile
     ? [
@@ -89,10 +89,16 @@ export default async function Page({
           <div className="flex min-w-[180%] items-stretch gap-4 lg:w-full lg:min-w-full lg:flex-col">
             <div className="w-1/2 snap-center lg:w-full lg:min-w-full">
               {/* 남 프로필이랑 내 프로필 구분 */}
-              <ProfileSection
-                initialUser={profileUser}
-                canEdit={isOwnProfile}
-              />
+              <Suspense
+                fallback={
+                  <ProfileSection initialUser={initialUser} canEdit={isOwnProfile} />
+                }
+              >
+                <ProfileSectionContainer
+                  profileUserPromise={profileUserPromise}
+                  canEdit={isOwnProfile}
+                />
+              </Suspense>
             </div>
             <div className="w-1/2 snap-center lg:w-full">
               <GradeCard />


### PR DESCRIPTION
## 🔗 Issue Number

- close: #456 

## 📝 Change Log

- 예전: page.tsx가 await getPublicUserProfile(...)를 직접 기다림 → 페이지 렌더가 그동안 멈춤
- 지금: page.tsx에서는 profileUserPromise만 만들어서 넘기고,Suspense의 src/app/users/[id]/_components/ProfileSectionContainer.tsx에서 기다림

## 💬 Reviewer's Guide

> 코드 리뷰 시 중점적으로 봐주었으면 하는 부분이나 논의가 필요한 지점을 적어주세요.

-
