### PR TITLE
[FIX] npm run build 타입 에러 수정 

### DIFF
--- a/src/components/layout/Gnb.tsx
+++ b/src/components/layout/Gnb.tsx
@@ -15,13 +15,13 @@ import axiosInstance from "@/lib/clientFetcher";
 import SideBar from "./SideBar";
 
 const BellIcon = ({ hasUnread }: { hasUnread: boolean }) => (
-  <div className="relative flex items-center justify-center p-1 bell-hover">
+  <div className="bell-hover relative flex items-center justify-center p-1">
     <Bell
       className="group-hover:text-main-purple h-5 w-5 text-slate-600 transition-colors"
       strokeWidth={2.2}
     />
     {hasUnread && (
-      <span className="absolute top-1 right-1 z-20 block h-1.5 w-1.5 rounded-full bg-main-purple ring-2 ring-white" />
+      <span className="bg-main-purple absolute top-1 right-1 z-20 block h-1.5 w-1.5 rounded-full ring-2 ring-white" />
     )}
   </div>
 );
@@ -39,7 +39,7 @@ const isNavActive = (pathname: string, href: string, exact?: boolean) => {
 };
 
 interface GnbProps {
-  initialUser?: { id: number; name: string; image: string | null } | null;
+  initialUser?: { id: number; name: string; image?: string | null } | null;
 }
 
 export function Gnb({ initialUser }: GnbProps) {
@@ -97,13 +97,13 @@ export function Gnb({ initialUser }: GnbProps) {
   }, [isNotificationOpen]);
 
   return (
-    <header className="sticky top-0 z-[100] flex h-16 w-full items-center justify-center border-b border-slate-200 bg-white/80 backdrop-blur-xl transition-all md:h-18 px-4 2xl:px-0">
+    <header className="sticky top-0 z-[100] flex h-16 w-full items-center justify-center border-b border-slate-200 bg-white/80 px-4 backdrop-blur-xl transition-all md:h-18 2xl:px-0">
       <div className="flex h-full w-full max-w-[1280px] items-center justify-between">
         {/* 왼쪽 영역 */}
         <div className="flex items-center gap-10 lg:gap-14">
           <Link
             href="/"
-            className="flex items-center transition-transform hover:scale-105 active:scale-95 focus-visible:ring-2 focus-visible:ring-black"
+            className="flex items-center transition-transform hover:scale-105 focus-visible:ring-2 focus-visible:ring-black active:scale-95"
           >
             <span className="text-main-purple text-2xl font-black tracking-tighter sm:text-3xl">
               co-git.
@@ -121,12 +121,15 @@ export function Gnb({ initialUser }: GnbProps) {
                     return;
                   }
                   isNavigating.current = true;
-                  setTimeout(() => {
-                    isNavigating.current = false;
-                  }, isNavActive(pathname, link.href, link.exact) ? 500 : 100);
+                  setTimeout(
+                    () => {
+                      isNavigating.current = false;
+                    },
+                    isNavActive(pathname, link.href, link.exact) ? 500 : 100,
+                  );
                 }}
                 className={cn(
-                  "relative py-2 px-4 text-sm font-bold tracking-tight transition-all focus-visible:ring-2 focus-visible:ring-black",
+                  "relative px-4 py-2 text-sm font-bold tracking-tight transition-all focus-visible:ring-2 focus-visible:ring-black",
                   isNavActive(pathname, link.href, link.exact)
                     ? "text-main-purple after:bg-main-purple after:absolute after:-bottom-1 after:left-1/2 after:h-[3px] after:w-5 after:-translate-x-1/2 after:rounded-full"
                     : "text-slate-400 hover:text-slate-900",
@@ -159,7 +162,6 @@ export function Gnb({ initialUser }: GnbProps) {
                 onClick={() => router.push(`/users/${user.id}`)}
                 aria-label="프로필 페이지 이동"
               >
-
                 {user?.image && !isBlobUrl ? (
                   <Image
                     src={user.image}
@@ -218,10 +220,7 @@ export function Gnb({ initialUser }: GnbProps) {
               aria-label="메뉴 열기"
             >
               <SheetTrigger className="flex h-8 w-8 items-center justify-center rounded-xl transition-all hover:bg-slate-50 active:scale-95">
-                <Menu
-                  className="h-5 w-5 text-slate-800"
-                  aria-hidden="true"
-                />
+                <Menu className="h-5 w-5 text-slate-800" aria-hidden="true" />
               </SheetTrigger>
               <SideBar
                 isLoggedIn={isLoggedIn}

--- a/src/lib/authCookies.ts
+++ b/src/lib/authCookies.ts
@@ -38,8 +38,8 @@ export function setUserDisplayCookie(
   user: {
     id: number;
     name: string;
-    image: string | null;
-    email: string;
+    image?: string | null;
+    email?: string;
     companyName: string;
   },
 ) {
@@ -48,8 +48,8 @@ export function setUserDisplayCookie(
     JSON.stringify({
       id: user.id,
       name: user.name,
-      image: user.image,
-      email: user.email,
+      image: user.image ?? null,
+      email: user.email ?? "",
       companyName: user.companyName,
     }),
     { ...COOKIE_OPTIONS, maxAge: USER_DISPLAY_MAX_AGE },


### PR DESCRIPTION
## 🔗 Issue Number

- close: #539 

현재 수정 방식은 “원본 타입이 optional을 허용하고 있으므로, 받는 쪽 타입도 동일하게 맞춘다”는 방향으로 정리했습니다.

src/lib/authCookies.ts

setUserDisplayCookie()의 인자 타입을 image?: string | null, email?: string으로 확장
저장 시에는 image: user.image ?? null, email: user.email ?? ""로 정규화하여
쿠키 데이터 shape는 안정적으로 유지

src/components/layout/Gnb.tsx

initialUser prop 타입을 image?: string | null을 허용하도록 변경
layout.tsx에서 넘기는 Pick<User, "id" | "name" | "image">와 동일한 방향으로 맞춤

Why This Approach

현재 User 타입 정의를 크게 바꾸지 않고 빌드 에러만 빠르게 해소할 수 있습니다.
optional 필드를 원본 타입 기준으로 일관되게 받아서, consumer 쪽이 불필요하게 더 좁은 타입을 요구하지 않도록 정리했습니다.
user_display 쿠키는 저장 시점에 기본값으로 정규화하여 실제 저장 데이터 형태는 일정하게 유지합니다.