### PR TITLE
[TEST] serverfetcher test

### DIFF
--- a/.github/ISSUE_TEMPLATE/test.md
+++ b/.github/ISSUE_TEMPLATE/test.md
@@ -2,7 +2,7 @@
 name: "🧪 Test: 테스트 코드 작성"
 about: 단위 테스트, E2E 테스트 및 기능 검증 로직 추가
 title: "[TEST] "
-labels: "test"
+labels: "tests"
 ---
 
 ## 🔍 Test Details

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,10 +1,7 @@
 import type { Config } from "jest";
 import nextJest from "next/jest.js";
 
-const createJestConfig = nextJest({
-  // Provide the path to your Next.js app to load next.config.js and .env files in your test environment
-  dir: "./",
-});
+const createJestConfig = nextJest({ dir: "./" });
 
 // Add any custom config to be passed to Jest
 const config: Config = {
@@ -16,7 +13,18 @@ const config: Config = {
   moduleNameMapper: {
     "^@/(.*)$": "<rootDir>/src/$1",
   },
+  testPathIgnorePatterns: ["/node_modules/", "/.claude/"],
 };
 
-// createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async
-export default createJestConfig(config);
+const jestConfigFn = createJestConfig(config);
+
+export default async () => {
+  const cfg = await jestConfigFn();
+  return {
+    ...cfg,
+    transformIgnorePatterns: [
+      "/node_modules/(?!(msw|rettime|until-async|type-fest)/)",
+      "/.next/",
+    ],
+  };
+};

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,13 +1,14 @@
 import "@testing-library/jest-dom";
 
-// IntersectionObserver가 없는 환경(JSDOM)에서 에러가 나지 않게 가짜(Mock)를 만듭니다.
-Object.defineProperty(window, "IntersectionObserver", {
-  writable: true,
-  configurable: true,
-  value: class {
-    constructor(private callback: IntersectionObserverCallback) {}
-    observe = jest.fn();
-    unobserve = jest.fn();
-    disconnect = jest.fn();
-  },
-});
+if (typeof window !== "undefined") {
+  Object.defineProperty(window, "IntersectionObserver", {
+    writable: true,
+    configurable: true,
+    value: class {
+      constructor(private callback: IntersectionObserverCallback) {}
+      observe = jest.fn();
+      unobserve = jest.fn();
+      disconnect = jest.fn();
+    },
+  });
+}

--- a/src/lib/serverFetcher.ts
+++ b/src/lib/serverFetcher.ts
@@ -342,4 +342,9 @@ async function serverFetch<T = unknown>(config: AxiosRequestConfig<T>) {
 // serverAxios 는 서버단에서 사용
 // serverFetch 는 서버컴포넌트용
 
-export { serverAxios, serverFetch };
+export {
+  serverAxios,
+  serverFetch,
+  isPublicPath,
+  getUserIdFromToken,
+};

--- a/src/tests/serverFetcher.test.ts
+++ b/src/tests/serverFetcher.test.ts
@@ -1,0 +1,541 @@
+/** @jest-environment node */
+
+import { setupServer } from "msw/node";
+import { http, HttpResponse } from "msw";
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import {
+  isPublicPath,
+  serverAxios,
+  serverFetch,
+} from "@/lib/serverFetcher";
+
+
+
+jest.mock("next/headers", () => ({ cookies: jest.fn() }));
+
+// Next.js 의 redirect() 는 실제로 NEXT_REDIRECT 에러를 throw 함 → 동일하게 모킹
+jest.mock("next/navigation", () => ({
+  redirect: jest.fn().mockImplementation((url: string) => {
+    throw Object.assign(new Error("NEXT_REDIRECT"), {
+      digest: `NEXT_REDIRECT;replace;${url};;`,
+    });
+  }),
+}));
+
+const BASE = process.env.NEXT_PUBLIC_API_URL!;
+
+/** sub 필드만 가진 최소 JWT 모킹 토큰 */
+function makeMockJwt(sub: string) {
+  const header = Buffer.from('{"alg":"HS256"}').toString("base64");
+  const payload = Buffer.from(JSON.stringify({ sub })).toString("base64");
+  return `${header}.${payload}.sig`;
+}
+
+/** cookies() 반환값을 원하는 토큰으로 세팅
+ *  set() 을 실제로 내부 store 에 반영 → setTokenCookies 호출 후 재시도 시 새 토큰 읽힘 */
+function setupCookies(tokens: { accessToken?: string; refreshToken?: string }) {
+  const store: Record<string, string | undefined> = { ...tokens };
+
+  (cookies as jest.Mock).mockResolvedValue({
+    get: (name: string) => (store[name] ? { value: store[name] } : undefined),
+    set: (name: string, value: string) => { store[name] = value; },
+  });
+}
+
+function setupCookiesWithSetFailure(tokens: { accessToken?: string; refreshToken?: string }) {
+  const store: Record<string, string | undefined> = { ...tokens };
+
+  (cookies as jest.Mock).mockResolvedValue({
+    get: (name: string) => (store[name] ? { value: store[name] } : undefined),
+    set: () => {
+      throw new Error("set-cookie-not-available");
+    },
+  });
+}
+
+
+const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+afterEach(() => {
+  server.resetHandlers();
+  jest.clearAllMocks();
+  // 맵 계속 남아서 그냥 초기화
+  const globalStore = globalThis as { __refreshMap?: Map<string, unknown> };
+  if (globalStore.__refreshMap) {
+    globalStore.__refreshMap.clear();
+  }
+});
+afterAll(() => server.close());
+
+// 비로그인 상태일 떄 접근 불가 페이지 확인
+
+describe("isPublicPath", () => {
+  it("/users/me → private", () => expect(isPublicPath(`${BASE}/users/me`)).toBe(false));
+  it("/meetings/123/join → private", () => expect(isPublicPath(`${BASE}/meetings/123/join`)).toBe(false));
+  it("/meetings/123/favorites → private", () => expect(isPublicPath(`${BASE}/meetings/123/favorites`)).toBe(false));
+  it("undefined → false", () => expect(isPublicPath(undefined)).toBe(false));
+});
+
+//  요청 시 경우의 수 확인
+
+describe("request interceptor", () => {
+  it("refreshToken 없고 public path면 요청을 통과시킨다", async () => {
+    setupCookies({});
+
+    let postsCallCount = 0;
+    let refreshCallCount = 0;
+
+    server.use(
+      http.post(`${BASE}/auth/refresh`, () => {
+        refreshCallCount++;
+        return HttpResponse.json({
+          accessToken: "should-not-be-called",
+          refreshToken: "rt",
+        });
+      }),
+      http.get(`${BASE}/posts`, () => {
+        postsCallCount++;
+        return HttpResponse.json({ data: [] });
+      }),
+    );
+
+    const response = await serverAxios.get("/posts");
+
+    expect(response.status).toBe(200);
+    expect(postsCallCount).toBe(1);
+    expect(refreshCallCount).toBe(0);
+  });
+
+  it("refreshToken 없고 private path면 요청을 차단한다", async () => {
+    setupCookies({});
+
+    let meCallCount = 0;
+    server.use(
+      http.get(`${BASE}/users/me`, () => {
+        meCallCount++;
+        return HttpResponse.json({ id: 1 });
+      }),
+    );
+
+    await expect(serverAxios.get("/users/me")).rejects.toMatchObject({
+      response: { status: 401, data: { code: "REFRESH_FAILED" } },
+    });
+    expect(meCallCount).toBe(0);
+  });
+
+  it("accessToken 이 있으면 refresh 없이 요청을 통과시킨다", async () => {
+    setupCookies({ accessToken: makeMockJwt("1"), refreshToken: makeMockJwt("1") });
+
+    let meetingsCallCount = 0;
+    let refreshCallCount = 0;
+
+    server.use(
+      http.post(`${BASE}/auth/refresh`, () => {
+        refreshCallCount++;
+        return HttpResponse.json({ accessToken: "unexpected", refreshToken: "unexpected" });
+      }),
+      http.get(`${BASE}/meetings`, () => {
+        meetingsCallCount++;
+        return HttpResponse.json({ data: [] });
+      }),
+    );
+
+    const response = await serverAxios.get("/meetings");
+
+    expect(response.status).toBe(200);
+    expect(meetingsCallCount).toBe(1);
+    expect(refreshCallCount).toBe(0);
+  });
+
+  it("accessToken 이 없고 refreshToken 이 있으면 refresh 후 요청을 통과시킨다", async () => {
+    setupCookies({ refreshToken: makeMockJwt("1") });
+
+    let meetingsCallCount = 0;
+    let refreshCallCount = 0;
+
+    server.use(
+      http.post(`${BASE}/auth/refresh`, () => {
+        refreshCallCount++;
+        return HttpResponse.json({ accessToken: "refreshed-token", refreshToken: "new-rt" });
+      }),
+      http.get(`${BASE}/meetings`, () => {
+        meetingsCallCount++;
+        return HttpResponse.json({ data: [] });
+      }),
+    );
+
+    const response = await serverAxios.get("/meetings");
+
+    expect(response.status).toBe(200);
+    expect(meetingsCallCount).toBe(1);
+    expect(refreshCallCount).toBe(1);
+  });
+
+  it("accessToken 이 없고 refreshToken 이 있지만 refresh 가 실패하면 요청을 차단한다", async () => {
+    setupCookies({ refreshToken: makeMockJwt("1") });
+
+    let meetingsCallCount = 0;
+    server.use(
+      http.post(`${BASE}/auth/refresh`, () =>
+        HttpResponse.json({ message: "expired" }, { status: 401 }),
+      ),
+      http.get(`${BASE}/meetings`, () => {
+        meetingsCallCount++;
+        return HttpResponse.json({ data: [] });
+      }),
+    );
+
+    await expect(serverAxios.get("/meetings")).rejects.toMatchObject({
+      response: { status: 401, data: { code: "REFRESH_FAILED" } },
+    });
+    expect(meetingsCallCount).toBe(0);
+  });
+});
+
+
+// 응답 인터셉터 경우의 수 확인
+
+describe("response interceptor", () => {
+
+  it("엑세스 토큰이 만료되었을경우", async () => {
+    const accessToken = makeMockJwt("1");
+    const refreshToken = makeMockJwt("1");
+    setupCookies({ accessToken, refreshToken });
+
+    let meCallCount = 0;
+    let refreshCallCount = 0;
+
+    server.use(
+      http.post(`${BASE}/auth/refresh`, () => {
+        refreshCallCount++;
+        return HttpResponse.json({ accessToken: "refreshed-token", refreshToken: "new-rt" });
+      }),
+      http.get(`${BASE}/users/me`, () => {
+        meCallCount++;
+        if (meCallCount === 1) {
+          return HttpResponse.json({}, { status: 401 });
+        }
+        return HttpResponse.json({ id: 1 });
+      }),
+    );
+
+    const response = await serverAxios.get("/users/me");
+
+    expect(response.data).toEqual({ id: 1 });
+    expect(meCallCount).toBe(2);
+    expect(refreshCallCount).toBe(1);
+  });
+
+  it("리프레쉬 토큰이 만료되었을경우 ", async () => {
+    const accessToken = makeMockJwt("1");
+    const refreshToken = makeMockJwt("1");
+    setupCookies({ accessToken, refreshToken });
+
+    let meCallCount = 0;
+    let refreshCallCount = 0;
+    server.use(
+      http.get(`${BASE}/users/me`, () => {
+        meCallCount++;
+        return HttpResponse.json({}, { status: 401 });
+      }),
+      http.post(`${BASE}/auth/refresh`, () => {
+        refreshCallCount++;
+        return HttpResponse.json({ message: "Expired" }, { status: 401 });
+      }),
+    );
+
+    await expect(serverAxios.get("/users/me")).rejects.toMatchObject({
+      response: { data: { code: "REFRESH_FAILED" } },
+    });
+    expect(meCallCount).toBe(1);
+    expect(refreshCallCount).toBe(1);
+  });
+
+  it("첫 요청 401 이후에 리프레쉬 성공했음에도 다음 요청이 401 이면 요청 차단 , 무한재시도 방어되는가 테스트 ", async () => {
+    const accessToken = makeMockJwt("1");
+    const refreshToken = makeMockJwt("1");
+    setupCookies({ accessToken, refreshToken });
+
+    let meCallCount = 0;
+    let refreshCallCount = 0;
+    server.use(
+      http.get(`${BASE}/users/me`, () => {
+        meCallCount++;
+        return HttpResponse.json({}, { status: 401 });
+      }),
+      http.post(`${BASE}/auth/refresh`, () => {
+        refreshCallCount++;
+        return HttpResponse.json({ accessToken: "new-token", refreshToken: "new-rt" });
+      }),
+    );
+
+    await expect(serverAxios.get("/users/me")).rejects.toMatchObject({
+      response: { status: 401 },
+    });
+    expect(meCallCount).toBe(2);
+    expect(refreshCallCount).toBe(1);
+  });
+
+  it("401 이 아닌 에러(403)는 refresh 안씀", async () => {
+    const accessToken = makeMockJwt("1");
+    const refreshToken = makeMockJwt("1");
+    setupCookies({ accessToken, refreshToken });
+
+    let refreshCallCount = 0;
+    server.use(
+      http.post(`${BASE}/auth/refresh`, () => {
+        refreshCallCount++;
+        return HttpResponse.json({ accessToken: "unexpected", refreshToken: "unexpected" });
+      }),
+      http.get(`${BASE}/users/me`, () =>
+        HttpResponse.json({ message: "Forbidden" }, { status: 403 }),
+      ),
+    );
+
+    await expect(serverAxios.get("/users/me")).rejects.toMatchObject({
+      response: { status: 403 },
+    });
+    expect(refreshCallCount).toBe(0);
+  });
+
+  it("401 응답에서 refreshToken 이 없으면 REFRESH_FAILED 로 차단한다", async () => {
+    const accessToken = makeMockJwt("1");
+    setupCookies({ accessToken }); // refreshToken 없음
+
+    server.use(
+      http.get(`${BASE}/users/me`, () => HttpResponse.json({}, { status: 401 })),
+    );
+
+    await expect(serverAxios.get("/users/me")).rejects.toMatchObject({
+      response: { status: 401, data: { code: "REFRESH_FAILED" } },
+    });
+  });
+});
+
+
+// refreshAccessToken — 동시 요청 처리
+
+describe("refreshAccessToken - 동시 요청 처리", () => {
+  it("같은 userId 의 동시 요청 refresh API 는 1번만 호출", async () => {
+    setupCookies({ refreshToken: makeMockJwt("1") }); // accessToken 없음 → 모두 refresh 트리거
+
+    let refreshCallCount = 0;
+    server.use(
+      http.post(`${BASE}/auth/refresh`, async () => {
+        refreshCallCount++;
+        await new Promise((r) => setTimeout(r, 30)); // 지연으로 동시성 재현
+        return HttpResponse.json({ accessToken: "concurrent-token", refreshToken: "new-rt" });
+      }),
+      http.get(`${BASE}/meetings`, () => HttpResponse.json({ data: [] })),
+    );
+
+    await Promise.all([
+      serverAxios.get("/meetings"),
+      serverAxios.get("/meetings"),
+      serverAxios.get("/meetings"),
+    ]);
+
+    expect(refreshCallCount).toBe(1);
+  });
+
+  it("첫 요청 후 refresh 결과를 캐시 → 이후 순차 요청도 refresh 1번", async () => {
+    setupCookies({ refreshToken: makeMockJwt("1") });
+
+    let refreshCallCount = 0;
+    server.use(
+      http.post(`${BASE}/auth/refresh`, () => {
+        refreshCallCount++;
+        return HttpResponse.json({ accessToken: "cached-token", refreshToken: "rt" });
+      }),
+      http.get(`${BASE}/meetings`, () => HttpResponse.json({ data: [] })),
+    );
+
+    await serverAxios.get("/meetings"); // refresh 발생
+    await serverAxios.get("/meetings"); // 캐시 사용
+
+    expect(refreshCallCount).toBe(1);
+  });
+
+  it("캐시된 토큰이 만료(401) → forceRefresh 로 새 refresh 수행", async () => {
+    setupCookies({ refreshToken: makeMockJwt("1") });
+
+    let refreshCallCount = 0;
+    server.use(
+      http.post(`${BASE}/auth/refresh`, () => {
+        refreshCallCount++;
+        if (refreshCallCount === 1) {
+          return HttpResponse.json({
+            accessToken: "cached-token",
+            refreshToken: makeMockJwt("1"),
+          });
+        }
+        return HttpResponse.json({
+          accessToken: "force-refreshed",
+          refreshToken: makeMockJwt("1"),
+        });
+      }),
+      http.get(`${BASE}/meetings`, () => HttpResponse.json({ data: [] })),
+      http.get(`${BASE}/users/me`, ({ request }) => {
+        const auth = request.headers.get("authorization");
+        if (auth === "Bearer cached-token") {
+          return HttpResponse.json({}, { status: 401 });
+        }
+        return HttpResponse.json({ id: 1 });
+      }),
+    );
+
+    await serverAxios.get("/meetings"); // refreshMap 에 cached-token 저장
+    const response = await serverAxios.get("/users/me"); // 401 후 forceRefresh
+
+    expect(response.data).toEqual({ id: 1 });
+    expect(refreshCallCount).toBe(2);
+  });
+
+  it("같은 userId에서 401 응답이 동시에 발생해도 forceRefresh 는 1번만 추가 호출", async () => {
+    setupCookies({ refreshToken: makeMockJwt("1") });
+
+    let refreshCallCount = 0;
+    server.use(
+      http.post(`${BASE}/auth/refresh`, async () => {
+        refreshCallCount++;
+        await new Promise((r) => setTimeout(r, 20));
+
+        if (refreshCallCount === 1) {
+          return HttpResponse.json({
+            accessToken: "cached-token",
+            refreshToken: makeMockJwt("1"),
+          });
+        }
+
+        return HttpResponse.json({
+          accessToken: "force-refreshed",
+          refreshToken: makeMockJwt("1"),
+        });
+      }),
+      http.get(`${BASE}/meetings`, () => HttpResponse.json({ data: [] })),
+      http.get(`${BASE}/users/me`, ({ request }) => {
+        const auth = request.headers.get("authorization");
+        if (auth === "Bearer cached-token") {
+          return HttpResponse.json({}, { status: 401 });
+        }
+        return HttpResponse.json({ id: 1 });
+      }),
+    );
+
+    //  캐시 토큰 생성 (refresh 1회)
+    await serverAxios.get("/meetings");
+
+    //  같은 시점 401 두 건 -> forceRefresh 동시 진입
+    const [res1, res2] = await Promise.all([
+      serverAxios.get("/users/me"),
+      serverAxios.get("/users/me"),
+    ]);
+
+    expect(res1.data).toEqual({ id: 1 });
+    expect(res2.data).toEqual({ id: 1 });
+    expect(refreshCallCount).toBe(2); // 초기 1회 + forceRefresh 1회
+  });
+
+  it("서로 다른 userId 요청은 캐시를 공유하지 않는지 테스트", async () => {
+    let refreshCallCount = 0;
+    server.use(
+      http.post(`${BASE}/auth/refresh`, () => {
+        refreshCallCount++;
+        return HttpResponse.json({ accessToken: `token-${refreshCallCount}`, refreshToken: `rt-${refreshCallCount}` });
+      }),
+      http.get(`${BASE}/meetings`, () => HttpResponse.json({ data: [] })),
+    );
+
+    setupCookies({ refreshToken: makeMockJwt("1") });
+    await serverAxios.get("/meetings");
+
+    setupCookies({ refreshToken: makeMockJwt("2") });
+    await serverAxios.get("/meetings");
+
+    expect(refreshCallCount).toBe(2);
+  });
+
+  // 나중에 개선
+  it("cookies().set 실패해도 refresh 결과로 요청은 계속 통과한다", async () => {
+    setupCookiesWithSetFailure({ refreshToken: makeMockJwt("1") });
+
+    let refreshCallCount = 0;
+    let meetingsCallCount = 0;
+
+    server.use(
+      http.post(`${BASE}/auth/refresh`, () => {
+        refreshCallCount++;
+        return HttpResponse.json({
+          accessToken: "fallback-token",
+          refreshToken: makeMockJwt("1"),
+        });
+      }),
+      http.get(`${BASE}/meetings`, ({ request }) => {
+        meetingsCallCount++;
+        const auth = request.headers.get("authorization");
+        if (auth !== "Bearer fallback-token") {
+          return HttpResponse.json({}, { status: 401 });
+        }
+        return HttpResponse.json({ data: [] });
+      }),
+    );
+
+    const first = await serverAxios.get("/meetings");
+    const second = await serverAxios.get("/meetings");
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(meetingsCallCount).toBe(2);
+    expect(refreshCallCount).toBe(1);
+  });
+});
+
+
+
+// 서버패치 테스트
+describe("serverFetch wrapper", () => {
+  it("성공 응답이면 redirect 없이 데이터를 그대로 반환한다", async () => {
+    const accessToken = makeMockJwt("1");
+    const refreshToken = makeMockJwt("1");
+    setupCookies({ accessToken, refreshToken });
+
+    server.use(
+      http.get(`${BASE}/users/me`, () => HttpResponse.json({ id: 1, name: "tester" })),
+    );
+
+    const response = await serverFetch({ method: "GET", url: "/users/me" });
+    expect(response.data).toEqual({ id: 1, name: "tester" });
+    expect(redirect).not.toHaveBeenCalled();
+  });
+
+  it("REFRESH_FAILED 에러 → redirect('/login') 를 호출한다", async () => {
+    setupCookies({}); // 토큰 없음 + private path → REFRESH_FAILED
+
+    // redirect() 가 NEXT_REDIRECT 를 throw 하므로 rejects 처리
+    await expect(
+      serverFetch({ method: "GET", url: "/users/me" }),
+    ).rejects.toThrow("NEXT_REDIRECT");
+
+    expect(redirect).toHaveBeenCalledWith("/login");
+  });
+
+  it("REFRESH_FAILED 가 아닌 에러(500) → redirect 없이 그냥 throw", async () => {
+    const accessToken = makeMockJwt("1");
+    const refreshToken = makeMockJwt("1");
+    setupCookies({ accessToken, refreshToken });
+
+    server.use(
+      http.get(`${BASE}/users/me`, () =>
+        HttpResponse.json({ message: "Internal Server Error" }, { status: 500 }),
+      ),
+    );
+
+    await expect(
+      serverFetch({ method: "GET", url: "/users/me" }),
+    ).rejects.toMatchObject({ response: { status: 500 } });
+
+    expect(redirect).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
### **User description**
## 🔗 Issue Number

- close: #575


___

### **PR Type**
Tests, Enhancement


___

### **Description**
- `serverFetcher` 인증 로직 테스트 코드를 추가했습니다.
    - Jest 설정에 `testPathIgnorePatterns` 및 `transformIgnorePatterns`를 추가했습니다.
    - `serverFetcher` 유틸리티 함수를 외부로 export하여 재사용성을 높였습니다.
    - `IntersectionObserver` 모킹 로직을 개선했습니다.


___

### Diagram Walkthrough


```mermaid
    flowchart LR
        A[사용자 요청] --> B{serverAxios 인터셉터};
        B --> C{Access Token 유효성 검사};
        C -- 유효함 --> D[원본 요청 진행];
        C -- 만료/없음 --> E{Refresh Token 존재?};
        E -- 없음 --> F[로그인 페이지로 리다이렉트];
        E -- 있음 --> G[Refresh API 호출];
        G -- 성공 --> H[새 Access Token으로 원본 요청 재시도];
        G -- 실패 --> F;
        H --> I[응답 반환];
        D --> I;
        I --> J[사용자에게 응답];
    ```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>jest.config.ts</strong><dd><code>Jest 설정 비동기화 및 트랜스폼/경로 무시 패턴 추가</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

jest.config.ts

<ul><li>Jest 설정에서 <code>createJestConfig</code> 함수를 비동기 방식으로 변경했습니다.<br> <li> 테스트 경로 무시 패턴(<code>testPathIgnorePatterns</code>)에 <code>/node_modules/</code>와 <code>/.claude/</code>를 <br>추가했습니다.<br> <li> <code>transformIgnorePatterns</code>를 추가하여 <code>msw</code>, <code>rettime</code> 등 특정 모듈의 트랜스폼을 예외 처리했습니다.</ul>


</details>


  </td>
  <td><a href="https://github.com/Codeit-13-Team6/geek-6hic/pull/576/files#diff-860bd1f15d1e0bafcfc6f62560524f588e6d6bf56d4ab1b0f6f8146461558730">+14/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>jest.setup.ts</strong><dd><code>`IntersectionObserver` 모킹 조건부 적용</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

jest.setup.ts

<ul><li><code>IntersectionObserver</code> 모킹 로직을 <code>window</code> 객체가 정의된 경우에만 적용하도록 변경했습니다.<br> <li> 이는 Node.js 환경에서 테스트할 때 발생할 수 있는 오류를 방지합니다.</ul>


</details>


  </td>
  <td><a href="https://github.com/Codeit-13-Team6/geek-6hic/pull/576/files#diff-a1c786cdea90125d840669112d499d337a658bf6431a8c972a2e14301d908662">+12/-11</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>serverFetcher.ts</strong><dd><code>`serverFetcher` 유틸리티 함수 외부 export</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lib/serverFetcher.ts

<ul><li><code>isPublicPath</code> 함수를 외부로 export하여 다른 모듈에서 사용할 수 있도록 했습니다.<br> <li> <code>getUserIdFromToken</code> 함수를 외부로 export하여 토큰에서 사용자 ID를 추출하는 로직을 재사용할 수 있도록 <br>했습니다.</ul>


</details>


  </td>
  <td><a href="https://github.com/Codeit-13-Team6/geek-6hic/pull/576/files#diff-75004b2c85abde6c79c7e57e85c63ff8d59dfe83564ff9da62662056a8672361">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>serverFetcher.test.ts</strong><dd><code>`serverFetcher` 인증 로직에 대한 포괄적인 테스트 코드 추가</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/tests/serverFetcher.test.ts

<ul><li><code>serverFetcher</code> 및 <code>serverAxios</code>의 인증 및 토큰 리프레시 로직에 대한 광범위한 단위 테스트를 추가했습니다.<br> <li> MSW(Mock Service Worker)를 사용하여 API 요청을 모킹하고 다양한 시나리오를 검증했습니다.<br> <li> 토큰 만료, 리프레시 실패, 동시 요청 처리, 리다이렉션 등의 케이스를 테스트했습니다.<br> <li> <code>next/headers</code>와 <code>next/navigation</code> 모듈을 Jest로 모킹하여 Next.js 환경을 시뮬레이션했습니다.</ul>


</details>


  </td>
  <td><a href="https://github.com/Codeit-13-Team6/geek-6hic/pull/576/files#diff-73bd29f5635b0cc8415ff69c257a846ae28eb03ed2590dc33072158749cc9685">+541/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test.md</strong><dd><code>이슈 템플릿 라벨명 변경</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/ISSUE_TEMPLATE/test.md

- 이슈 템플릿의 기본 라벨을 `test`에서 `tests`로 변경했습니다.


</details>


  </td>
  <td><a href="https://github.com/Codeit-13-Team6/geek-6hic/pull/576/files#diff-240b7c16f05a69d582f3f8a5842158a572abe6f30d373ce91b31615aaf58221b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

