### PR TITLE
[TEST] meetings detail 뷰 렌더링 테스트 작성

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "start": "next start",
     "lint": "eslint --cache src",
     "lint:fix": "eslint --cache src --fix",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "test": "jest",
+    "test:watch": "jest --watch"
   },
   "dependencies": {
     "@base-ui/react": "1.3.0",
@@ -66,9 +68,5 @@
   },
   "engines": {
     "node": ">=20.9.0"
-  },
-  "scripts": {
-    "test": "jest",
-    "test:watch": "jest --watch"
   }
 }

--- a/src/tests/meetings/detail/MeetingDetailContent.test.tsx
+++ b/src/tests/meetings/detail/MeetingDetailContent.test.tsx
@@ -1,0 +1,130 @@
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { MeetingDetailContent } from "@/app/meetings/[id]/_components/MeetingDetailContent";
+import { useMeetingDetailQueries } from "@/hooks";
+import { useAuthStore } from "@/store/useAuthStore";
+import { MeetingDetailApiData, MeetingParticipant } from "@/types";
+// 이 테스트는 상세 설명과 하위 섹션이 화면에 렌더링되는지만 확인한다.
+
+// 상세 뷰 테스트에 필요한 목데이터를 이 파일 안에 함께 둔다.
+const mockParticipants: MeetingParticipant[] = [
+  {
+    id: 1,
+    teamId: "team-1",
+    meetingId: 101,
+    userId: 1,
+    joinedAt: "2026-04-01T00:00:00.000Z",
+    user: {
+      id: 1,
+      name: "호스트",
+      image: null,
+    },
+  },
+  {
+    id: 2,
+    teamId: "team-1",
+    meetingId: 101,
+    userId: 2,
+    joinedAt: "2026-04-01T00:00:00.000Z",
+    user: {
+      id: 2,
+      name: "김코드",
+      image: null,
+    },
+  },
+];
+
+const mockDetail: MeetingDetailApiData = {
+  id: 101,
+  teamId: "team-1",
+  name: "프론트엔드 스터디",
+  type: "frontend",
+  region: "1",
+  address: "https://meet.example.com",
+  latitude: 0,
+  longitude: 0,
+  dateTime: "2099-12-31T12:00:00.000Z",
+  registrationEnd: "2099-12-30T12:00:00.000Z",
+  capacity: 10,
+  image: null,
+  description: "테스트용 모임입니다.",
+  participantCount: 2,
+  canceledAt: null,
+  confirmedAt: null,
+  hostId: 1,
+  createdBy: 1,
+  createdAt: "2026-04-01T00:00:00.000Z",
+  updatedAt: "2026-04-01T00:00:00.000Z",
+  host: {
+    id: 1,
+    name: "호스트",
+    image: null,
+  },
+  isFavorited: false,
+  isCompleted: false,
+  isJoined: true,
+};
+
+jest.mock("@/hooks", () => ({
+  useMeetingDetailQueries: jest.fn(),
+}));
+
+jest.mock("@/store/useAuthStore", () => ({
+  useAuthStore: jest.fn(),
+}));
+
+// 이 테스트는 컨테이너 렌더링과 데이터 전달만 보기 위해 하위 섹션을 mock 처리한다.
+jest.mock("next/dist/client/components/error-boundary", () => ({
+  ErrorBoundary: ({ children }: { children: ReactNode }) => children,
+}));
+
+jest.mock("@/app/meetings/[id]/_components/MeetingHeaderSection", () => ({
+  MeetingHeaderSection: ({ detail }: { detail: { name: string } }) => (
+    <h1>{detail.name}</h1>
+  ),
+}));
+
+jest.mock("@/app/meetings/[id]/_components/MeetingLinkSection", () => ({
+  MeetingLinkSection: ({ link }: { link: string }) => <a href={link}>{link}</a>,
+}));
+
+jest.mock("@/app/meetings/[id]/_components/MeetingThreadSection", () => ({
+  MeetingThreadSection: () => <div>thread-section</div>,
+}));
+
+jest.mock("@/app/meetings/[id]/_components/RecommendedMeetingsSection", () => ({
+  RecommendedMeetingsSection: () => <div>recommended-section</div>,
+}));
+
+const mockedUseAuthStore = useAuthStore as jest.MockedFunction<
+  typeof useAuthStore
+>;
+const mockedUseMeetingDetailQueries =
+  useMeetingDetailQueries as jest.MockedFunction<
+    typeof useMeetingDetailQueries
+  >;
+
+describe("MeetingDetailContent", () => {
+  test("상세 설명과 하위 섹션이 보인다", () => {
+    // 실제 API나 스토어 없이도 렌더링되도록 고정된 값을 주입한다.
+    mockedUseAuthStore.mockReturnValue({ id: 1 } as never);
+
+    mockedUseMeetingDetailQueries.mockReturnValue({
+      detailQuery: { data: mockDetail },
+      participantsQuery: { data: { data: mockParticipants } },
+    } as never);
+
+    render(<MeetingDetailContent meetingId={101} />);
+
+    // 상세 설명과 하위 섹션들이 함께 렌더링되는지 확인한다.
+    expect(
+      screen.getByRole("heading", { name: "프론트엔드 스터디" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("테스트용 모임입니다.")).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "https://meet.example.com" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("thread-section")).toBeInTheDocument();
+    expect(screen.getByText("recommended-section")).toBeInTheDocument();
+  });
+});

--- a/src/tests/meetings/detail/MeetingHeaderSection.test.tsx
+++ b/src/tests/meetings/detail/MeetingHeaderSection.test.tsx
@@ -1,0 +1,229 @@
+import { render, screen } from "@testing-library/react";
+import type { ImgHTMLAttributes, ReactNode } from "react";
+import { MeetingHeaderSection } from "@/app/meetings/[id]/_components/MeetingHeaderSection";
+import type { MeetingDetailApiData, MeetingParticipant } from "@/types";
+// 이 테스트는 mock 데이터를 기준으로 헤더 영역의 제목, 참여자 정보, 버튼 렌더링만 확인한다.
+
+// 렌더링만 확인하는 테스트이므로 외부 UI/상태 의존성은 mock 처리한다.
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+  }),
+}));
+
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: (props: ImgHTMLAttributes<HTMLImageElement>) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img {...props} alt={props.alt ?? ""} />
+  ),
+}));
+
+jest.mock("lottie-react", () => ({
+  __esModule: true,
+  default: () => <div>lottie</div>,
+}));
+
+jest.mock("@/assets/icon/meatballs/meatballs-lg.svg", () => "meatballs-icon");
+jest.mock("@/assets/lottie/check-anim.json", () => ({}));
+
+jest.mock("@/app/meetings/_components/modal/EditMeetingModal", () => ({
+  EditMeetingModal: () => null,
+}));
+
+jest.mock("@/components/modal/DeleteModal", () => ({
+  DeleteModal: () => null,
+}));
+
+jest.mock("@/components/modal/ConfirmModal", () => ({
+  ConfirmModal: () => null,
+}));
+
+jest.mock("@/components/modal/ModalBase", () => ({
+  __esModule: true,
+  default: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+jest.mock("@/components/ui/InputCommon", () => ({
+  InputCommon: () => null,
+}));
+
+jest.mock("@/components/img/FallbackImage", () => ({
+  __esModule: true,
+  default: ({ alt }: { alt: string }) => <img alt={alt} />,
+}));
+
+jest.mock("@/components/icon/HeartIcon", () => ({
+  HeartIcon: () => <button type="button">favorite</button>,
+}));
+
+jest.mock("@/components/ui/BtnCommon", () => ({
+  BtnCommon: ({ children, ...props }: { children: ReactNode }) => (
+    <button type="button" {...props}>
+      {children}
+    </button>
+  ),
+}));
+
+jest.mock("@/components/ui/DropdownCommon", () => ({
+  DropdownMenu: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuContent: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuItem: ({ children }: { children: ReactNode }) => (
+    <button type="button">{children}</button>
+  ),
+  DropdownMenuTrigger: ({ render }: { render: ReactNode }) => <>{render}</>,
+}));
+
+jest.mock("@/store/useLoginModalStore", () => ({
+  useLoginModalStore: (
+    selector: (state: {
+      loginGuardAction: (fn: () => void) => void;
+    }) => unknown,
+  ) =>
+    selector({
+      loginGuardAction: (fn: () => void) => fn(),
+    }),
+}));
+
+jest.mock("@/store/useAuthStore", () => ({
+  useAuthStore: (selector: (state: { isAuthLoading: boolean }) => unknown) =>
+    selector({
+      isAuthLoading: false,
+    }),
+}));
+
+jest.mock("@/hooks", () => ({
+  useMeetingJoinMutations: () => ({
+    isJoinPending: false,
+    handleJoinMeeting: jest.fn(),
+    handleCancelJoinMeeting: jest.fn(),
+  }),
+  useMeetingHostMutations: () => ({
+    handleEditMeeting: jest.fn(),
+    handleDeleteMeeting: jest.fn(),
+  }),
+  useMeetingAttendMutation: () => ({
+    hasAttended: false,
+    isCheckingAttendance: false,
+    handleAttendMeeting: jest.fn(),
+  }),
+  useMeetingDetailFavoriteMutation: () => ({
+    isFavoritePending: false,
+    handleToggleFavorite: jest.fn(),
+  }),
+}));
+
+jest.mock("@/lib/meetingSecret", () => ({
+  extractSecretCode: () => "1234",
+  isSecretMeeting: () => false,
+  verifySecretCode: () => true,
+}));
+
+jest.mock("@/lib/share", () => ({
+  shareLink: jest.fn(),
+}));
+
+jest.mock("@/lib/utils", () => ({
+  cn: (...classes: string[]) => classes.filter(Boolean).join(" "),
+  copyToClipboard: jest.fn(),
+}));
+
+// 헤더에 표시되는 제목, 참여자, 버튼 정보를 확인하기 위한 최소 목데이터이다.
+const mockDetail: MeetingDetailApiData = {
+  id: 101,
+  teamId: "team-1",
+  name: "프론트엔드 스터디",
+  type: "frontend",
+  region: "1",
+  address: "https://meet.example.com",
+  latitude: 0,
+  longitude: 0,
+  dateTime: "2099-12-31T12:00:00.000Z",
+  registrationEnd: "2099-12-30T12:00:00.000Z",
+  capacity: 10,
+  image: null,
+  description: "테스트용 모임입니다.",
+  participantCount: 2,
+  canceledAt: null,
+  confirmedAt: null,
+  hostId: 1,
+  createdBy: 1,
+  createdAt: "2026-04-01T00:00:00.000Z",
+  updatedAt: "2026-04-01T00:00:00.000Z",
+  host: {
+    id: 1,
+    name: "호스트",
+    image: null,
+  },
+  isFavorited: false,
+  isCompleted: false,
+  isJoined: true,
+};
+
+const mockParticipants: MeetingParticipant[] = [
+  {
+    id: 1,
+    teamId: "team-1",
+    meetingId: 101,
+    userId: 1,
+    joinedAt: "2026-04-01T00:00:00.000Z",
+    user: {
+      id: 1,
+      name: "호스트",
+      image: null,
+    },
+  },
+  {
+    id: 2,
+    teamId: "team-1",
+    meetingId: 101,
+    userId: 2,
+    joinedAt: "2026-04-01T00:00:00.000Z",
+    user: {
+      id: 2,
+      name: "김코드",
+      image: null,
+    },
+  },
+];
+
+describe("MeetingHeaderSection", () => {
+  test("목데이터로 받은 헤더 정보가 화면에 보인다", () => {
+    render(
+      <MeetingHeaderSection
+        meetingId={101}
+        detail={mockDetail}
+        participants={mockParticipants}
+        isHost={false}
+        isJoined={true}
+        isLoggedIn={true}
+      />,
+    );
+
+    // 모임 제목이 heading 요소로 렌더링되는지 확인한다.
+    expect(
+      screen.getByRole("heading", { name: "프론트엔드 스터디" }),
+    ).toBeInTheDocument();
+
+    // 참여 인원 텍스트는 중첩된 요소로 나뉠 수 있어 textContent 기준으로 확인한다.
+    expect(
+      screen.getAllByText((_, element) => {
+        const text = element?.textContent?.replace(/\s/g, "") ?? "";
+        return text.includes("2") && text.includes("/10");
+      }).length,
+    ).toBeGreaterThan(0);
+
+    // 참여자 이름으로 만들어지는 프로필 alt 텍스트가 보이는지 확인한다.
+    expect(screen.getByAltText(/호스트/)).toBeInTheDocument();
+    expect(screen.getByAltText(/김코드/)).toBeInTheDocument();
+
+    // 좋아요 액션은 단순 버튼으로 mock 했기 때문에 존재 여부만 확인한다.
+    expect(
+      screen.getByRole("button", { name: "favorite" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/tests/meetings/detail/MeetingLinkSection.test.tsx
+++ b/src/tests/meetings/detail/MeetingLinkSection.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from "@testing-library/react";
+import { MeetingLinkSection } from "@/app/meetings/[id]/_components/MeetingLinkSection";
+// 이 테스트는 기능 동작 없이 전달된 링크가 화면에 렌더링되는지만 확인한다.
+
+describe("MeetingLinkSection", () => {
+  test("전달받은 링크가 화면에 보인다", () => {
+    render(
+      <MeetingLinkSection
+        link="https://meet.example.com"
+        canViewLink={true}
+        isLoggedIn={true}
+      />,
+    );
+
+    // 전달한 링크가 anchor 요소로 렌더링되는지만 확인한다.
+    expect(
+      screen.getByRole("link", { name: /https:\/\/meet\.example\.com/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/tests/meetings/detail/MeetingThreadSection.test.tsx
+++ b/src/tests/meetings/detail/MeetingThreadSection.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from "@testing-library/react";
+import { MeetingThreadSection } from "@/app/meetings/[id]/_components/MeetingThreadSection";
+import { useMeetingThread } from "@/hooks/queries/useThread";
+// 이 테스트는 실제 스레드 생성/조회 로직이 아니라 스레드 영역의 렌더링만 확인한다.
+
+// 실제 스레드 훅을 mock 처리해서 렌더링 결과만 확인한다.
+jest.mock("@/hooks/queries/useThread", () => ({
+  useMeetingThread: jest.fn(),
+}));
+
+jest.mock("@/components/features/comment/CommentSection", () => ({
+  __esModule: true,
+  default: ({ postId }: { postId: number }) => (
+    <div>thread-comments-{postId}</div>
+  ),
+}));
+
+jest.mock("@/lib/utils", () => ({
+  cn: (...classes: string[]) => classes.filter(Boolean).join(" "),
+}));
+
+describe("MeetingThreadSection", () => {
+  test("스레드 댓글 영역이 보인다", () => {
+    // 스레드 글이 이미 존재하는 상황을 가정한다.
+    (useMeetingThread as jest.Mock).mockReturnValue({
+      threadPost: {
+        id: 301,
+        _count: { comments: 0 },
+      },
+      isPostLoading: false,
+      hasComments: false,
+    });
+
+    render(
+      <MeetingThreadSection
+        meetingId={101}
+        canWriteThread={true}
+        isLoggedIn={true}
+      />,
+    );
+
+    // mock 된 댓글 컴포넌트가 보이면 스레드 영역이 렌더링된 것으로 본다.
+    expect(screen.getByText("thread-comments-301")).toBeInTheDocument();
+  });
+});

--- a/src/tests/meetings/detail/RecommendedMeetingsSection.test.tsx
+++ b/src/tests/meetings/detail/RecommendedMeetingsSection.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { RecommendedMeetingsSection } from "@/app/meetings/[id]/_components/RecommendedMeetingsSection";
+import { useMeetingRecommendationsQuery } from "@/hooks";
+import { RecommendedMeetingItem } from "@/types";
+// 이 테스트는 추천 데이터가 들어왔을 때 추천 모임 링크가 화면에 보이는지만 확인한다.
+
+// 추천 모임이 화면에 렌더링되는지 확인하기 위한 목데이터이다.
+const mockRecommendations: RecommendedMeetingItem[] = [
+  {
+    id: 201,
+    name: "추천 모임 A",
+    image: null,
+    participantCount: 3,
+    capacity: 10,
+    registrationEnd: "2099-12-30T12:00:00.000Z",
+    dateTime: "2099-12-31T12:00:00.000Z",
+  },
+];
+
+jest.mock("@/hooks", () => ({
+  useMeetingRecommendationsQuery: jest.fn(),
+}));
+
+jest.mock("@/hooks/useDragScroll", () => ({
+  useDragScroll: () => ({ dragProps: {} }),
+}));
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ href, children }: { href: string; children: ReactNode }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+jest.mock("@/components/img/FallbackImage", () => ({
+  __esModule: true,
+  default: ({ alt }: { alt: string }) => <img alt={alt} />,
+}));
+
+describe("RecommendedMeetingsSection", () => {
+  test("추천 모임 이름이 링크로 보인다", () => {
+    // 실제 조회 대신 mock 데이터를 반환하도록 설정한다.
+    (useMeetingRecommendationsQuery as jest.Mock).mockReturnValue({
+      data: mockRecommendations,
+      isPending: false,
+    });
+
+    render(
+      <RecommendedMeetingsSection meetingId={101} meetingType="frontend" />,
+    );
+
+    // 추천 모임 이름이 링크 형태로 보이는지 확인한다.
+    expect(
+      screen.getByRole("link", { name: /추천 모임 A/ }),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 🔗 Issue Number

- close: #570 

## 작업 내용

- `meetings/[id]/_components` 하위 상세 페이지 컴포넌트에 대한 테스트 코드를 추가했습니다.
- mock 데이터를 기준으로 제목, 링크, 텍스트, 버튼 등 핵심 UI 요소가 화면에 정상적으로 렌더링되는지 확인했습니다.
- 기능 동작이나 API 검증은 제외하고, 컴포넌트 단위의 뷰 렌더링 확인에 집중했습니다.

## 테스트 대상

- `MeetingHeaderSection`
- `MeetingLinkSection`
- `MeetingThreadSection`
- `RecommendedMeetingsSection`
- `MeetingDetailContent`